### PR TITLE
[KLC-1371] Update get network status method in proxy client

### DIFF
--- a/clients/klever/proxy/baseProxy_test.go
+++ b/clients/klever/proxy/baseProxy_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/klever-io/klv-bridge-eth-go/clients/klever/proxy/endpointProviders"
 	"github.com/klever-io/klv-bridge-eth-go/clients/klever/proxy/models"
 	"github.com/klever-io/klv-bridge-eth-go/testsCommon"
-	"github.com/multiversx/mx-sdk-go/data"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -108,10 +107,8 @@ func TestBaseProxy_GetNetworkStatus(t *testing.T) {
 	t.Run("response error - node endpoint provider", func(t *testing.T) {
 		t.Parallel()
 
-		resp := &data.NodeStatusResponse{
-			Data: struct {
-				Status *data.NetworkStatus `json:"metrics"`
-			}{},
+		resp := &models.NodeOverviewApiResponse{
+			Data:  models.NodeOverviewResponseData{},
 			Error: expectedErr.Error(),
 			Code:  "",
 		}

--- a/clients/klever/proxy/baseProxy_test.go
+++ b/clients/klever/proxy/baseProxy_test.go
@@ -1,0 +1,189 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/klever-io/klever-go/tools/check"
+	"github.com/klever-io/klv-bridge-eth-go/clients/klever/proxy/endpointProviders"
+	"github.com/klever-io/klv-bridge-eth-go/clients/klever/proxy/models"
+	"github.com/klever-io/klv-bridge-eth-go/testsCommon"
+	"github.com/multiversx/mx-sdk-go/data"
+	"github.com/stretchr/testify/assert"
+)
+
+func createMockArgsBaseProxy() argsBaseProxy {
+	return argsBaseProxy{
+		httpClientWrapper: &testsCommon.HTTPClientWrapperStub{},
+		expirationTime:    time.Second,
+		endpointProvider:  endpointProviders.NewNodeEndpointProvider(),
+	}
+}
+
+func TestNewBaseProxy(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil http client wrapper", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockArgsBaseProxy()
+		args.httpClientWrapper = nil
+		baseProxyInstance, err := newBaseProxy(args)
+
+		assert.True(t, check.IfNil(baseProxyInstance))
+		assert.True(t, errors.Is(err, ErrNilHTTPClientWrapper))
+	})
+	t.Run("invalid caching duration", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockArgsBaseProxy()
+		args.expirationTime = time.Second - time.Nanosecond
+		baseProxyInstance, err := newBaseProxy(args)
+
+		assert.True(t, check.IfNil(baseProxyInstance))
+		assert.True(t, errors.Is(err, ErrInvalidCacherDuration))
+	})
+	t.Run("nil endpoint provider", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockArgsBaseProxy()
+		args.endpointProvider = nil
+		baseProxyInstance, err := newBaseProxy(args)
+
+		assert.True(t, check.IfNil(baseProxyInstance))
+		assert.True(t, errors.Is(err, ErrNilEndpointProvider))
+	})
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockArgsBaseProxy()
+		baseProxyInstance, err := newBaseProxy(args)
+
+		assert.False(t, check.IfNil(baseProxyInstance))
+		assert.Nil(t, err)
+	})
+}
+
+func TestBaseProxy_GetNetworkStatus(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("expected error")
+	t.Run("get errors", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockArgsBaseProxy()
+		args.httpClientWrapper = &testsCommon.HTTPClientWrapperStub{
+			GetHTTPCalled: func(ctx context.Context, endpoint string) ([]byte, int, error) {
+				return nil, http.StatusBadRequest, expectedErr
+			},
+		}
+		baseProxyInstance, _ := newBaseProxy(args)
+
+		result, err := baseProxyInstance.GetNetworkStatus(context.Background())
+		assert.Nil(t, result)
+		assert.True(t, errors.Is(err, expectedErr))
+		assert.True(t, strings.Contains(err.Error(), http.StatusText(http.StatusBadRequest)))
+	})
+	t.Run("malformed response - node endpoint provider", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockArgsBaseProxy()
+		args.httpClientWrapper = &testsCommon.HTTPClientWrapperStub{
+			GetHTTPCalled: func(ctx context.Context, endpoint string) ([]byte, int, error) {
+				return []byte("malformed response"), http.StatusOK, nil
+			},
+		}
+		baseProxyInstance, _ := newBaseProxy(args)
+
+		result, err := baseProxyInstance.GetNetworkStatus(context.Background())
+		assert.Nil(t, result)
+		assert.NotNil(t, err)
+		assert.True(t, strings.Contains(err.Error(), "invalid character 'm'"))
+	})
+	t.Run("response error - node endpoint provider", func(t *testing.T) {
+		t.Parallel()
+
+		resp := &data.NodeStatusResponse{
+			Data: struct {
+				Status *data.NetworkStatus `json:"metrics"`
+			}{},
+			Error: expectedErr.Error(),
+			Code:  "",
+		}
+		respBytes, _ := json.Marshal(resp)
+
+		args := createMockArgsBaseProxy()
+		args.httpClientWrapper = &testsCommon.HTTPClientWrapperStub{
+			GetHTTPCalled: func(ctx context.Context, endpoint string) ([]byte, int, error) {
+				return respBytes, http.StatusOK, nil
+			},
+		}
+		baseProxyInstance, _ := newBaseProxy(args)
+
+		result, err := baseProxyInstance.GetNetworkStatus(context.Background())
+		assert.Nil(t, result)
+		assert.NotNil(t, err)
+		assert.True(t, strings.Contains(err.Error(), expectedErr.Error()))
+	})
+	t.Run("GetNodeStatus returns nil network status - node endpoint provider", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockArgsBaseProxy()
+		args.httpClientWrapper = &testsCommon.HTTPClientWrapperStub{
+			GetHTTPCalled: func(ctx context.Context, endpoint string) ([]byte, int, error) {
+				return getNodeStatusBytes(nil), http.StatusOK, nil
+			},
+		}
+		baseProxyInstance, _ := newBaseProxy(args)
+
+		result, err := baseProxyInstance.GetNetworkStatus(context.Background())
+		assert.Nil(t, result)
+		assert.True(t, errors.Is(err, ErrNilNetworkStatus))
+	})
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		providedNetworkStatus := &models.NodeOverview{
+			EpochNumber:       2,
+			Nonce:             3,
+			NonceAtEpochStart: 4,
+		}
+
+		args := createMockArgsBaseProxy()
+		args.httpClientWrapper = &testsCommon.HTTPClientWrapperStub{
+			GetHTTPCalled: func(ctx context.Context, endpoint string) ([]byte, int, error) {
+				return getNodeStatusBytes(providedNetworkStatus), http.StatusOK, nil
+			},
+		}
+		baseProxyInstance, _ := newBaseProxy(args)
+
+		result, err := baseProxyInstance.GetNetworkStatus(context.Background())
+		assert.Nil(t, err)
+		assert.Equal(t, providedNetworkStatus, result)
+	})
+}
+
+func getNodeStatusBytes(status *models.NodeOverview) []byte {
+	resp := &models.NodeOverviewApiResponse{
+		Data: models.NodeOverviewResponseData{
+			NodeOverview: status,
+		},
+	}
+	respBytes, _ := json.Marshal(resp)
+
+	return respBytes
+}
+
+func TestBaseProxy_GetRestAPIEntityType(t *testing.T) {
+	t.Parallel()
+
+	args := createMockArgsBaseProxy()
+	baseProxyInstance, _ := newBaseProxy(args)
+
+	assert.Equal(t, args.endpointProvider.GetRestAPIEntityType(), baseProxyInstance.GetRestAPIEntityType())
+}

--- a/clients/klever/proxy/endpointProviders/baseEndpointProvider.go
+++ b/clients/klever/proxy/endpointProviders/baseEndpointProvider.go
@@ -4,6 +4,7 @@ import "fmt"
 
 const (
 	networkConfig              = "network/config"
+	nodeStatus                 = "node/overview"
 	account                    = "address/%s"
 	estimateTransactionFees    = "transaction/estimate-fee"
 	sendTransaction            = "transaction/send"
@@ -20,6 +21,11 @@ type baseEndpointProvider struct{}
 // GetNetworkConfig returns the network config endpoint
 func (base *baseEndpointProvider) GetNetworkConfig() string {
 	return networkConfig
+}
+
+// GetNodeStatus returns the network status endpoint
+func (base *baseEndpointProvider) GetNodeStatus() string {
+	return nodeStatus
 }
 
 // GetAccount returns the account endpoint

--- a/clients/klever/proxy/endpointProviders/nodeEndpointProvider.go
+++ b/clients/klever/proxy/endpointProviders/nodeEndpointProvider.go
@@ -4,10 +4,6 @@ import (
 	"github.com/klever-io/klv-bridge-eth-go/clients/klever/proxy/models"
 )
 
-const (
-	nodeGetNodeStatusEndpoint = "node/status"
-)
-
 // nodeEndpointProvider is suitable to work with a MultiversX node (observer)
 type nodeEndpointProvider struct {
 	*baseEndpointProvider
@@ -18,11 +14,6 @@ func NewNodeEndpointProvider() *nodeEndpointProvider {
 	return &nodeEndpointProvider{
 		baseEndpointProvider: &baseEndpointProvider{},
 	}
-}
-
-// GetNodeStatus returns the node status endpoint
-func (node *nodeEndpointProvider) GetNodeStatus() string {
-	return nodeGetNodeStatusEndpoint
 }
 
 // GetRestAPIEntityType returns the observer node constant

--- a/clients/klever/proxy/endpointProviders/nodeEndpointProvider_test.go
+++ b/clients/klever/proxy/endpointProviders/nodeEndpointProvider_test.go
@@ -15,13 +15,6 @@ func TestNewNodeEndpointProvider(t *testing.T) {
 	assert.False(t, check.IfNil(provider))
 }
 
-func TestNodeEndpointProvider_GetNodeStatus(t *testing.T) {
-	t.Parallel()
-
-	provider := NewNodeEndpointProvider()
-	assert.Equal(t, nodeGetNodeStatusEndpoint, provider.GetNodeStatus())
-}
-
 func TestNodeEndpointProvider_Getters(t *testing.T) {
 	t.Parallel()
 

--- a/clients/klever/proxy/endpointProviders/proxyEndpointProvider.go
+++ b/clients/klever/proxy/endpointProviders/proxyEndpointProvider.go
@@ -4,10 +4,6 @@ import (
 	"github.com/klever-io/klv-bridge-eth-go/clients/klever/proxy/models"
 )
 
-const (
-	proxyGetNodeStatus = "network/status/"
-)
-
 // proxyEndpointProvider is suitable to work with a MultiversX Proxy
 type proxyEndpointProvider struct {
 	*baseEndpointProvider
@@ -18,11 +14,6 @@ func NewProxyEndpointProvider() *proxyEndpointProvider {
 	return &proxyEndpointProvider{
 		baseEndpointProvider: &baseEndpointProvider{},
 	}
-}
-
-// GetNodeStatus returns the node status endpoint
-func (proxy *proxyEndpointProvider) GetNodeStatus() string {
-	return proxyGetNodeStatus
 }
 
 // GetRestAPIEntityType returns the proxy constant

--- a/clients/klever/proxy/endpointProviders/proxyEndpointProvider_test.go
+++ b/clients/klever/proxy/endpointProviders/proxyEndpointProvider_test.go
@@ -13,10 +13,3 @@ func TestNewProxyEndpointProvider(t *testing.T) {
 	provider := NewProxyEndpointProvider()
 	assert.False(t, check.IfNil(provider))
 }
-
-func TestProxyEndpointProvider_GetNodeStatus(t *testing.T) {
-	t.Parallel()
-
-	provider := NewProxyEndpointProvider()
-	assert.Equal(t, "network/status/", provider.GetNodeStatus())
-}

--- a/clients/klever/proxy/models/network.go
+++ b/clients/klever/proxy/models/network.go
@@ -2,6 +2,13 @@ package models
 
 import "time"
 
+// GenericApiResponse defines the structure of a generic response type
+type GenericApiResponse struct {
+	Data  interface{} `json:"data"`
+	Error string      `json:"error"`
+	Code  string      `json:"code"`
+}
+
 type NetworkConfig struct {
 	NumMetachainNodes  uint64 `json:"klv_num_metachain_nodes"`
 	ConsensusGroupSize uint64 `json:"klv_consensus_group_size"`

--- a/clients/klever/proxy/models/network.go
+++ b/clients/klever/proxy/models/network.go
@@ -44,7 +44,7 @@ type NodeOverviewResponseData struct {
 }
 
 type NodeOverviewApiResponse struct {
-	Data  NodeOverviewResponseData
-	Error string `json:"error"`
-	Code  string `json:"code"`
+	Data  NodeOverviewResponseData `json:"data"`
+	Error string                   `json:"error"`
+	Code  string                   `json:"code"`
 }

--- a/clients/klever/proxy/models/network.go
+++ b/clients/klever/proxy/models/network.go
@@ -32,12 +32,12 @@ type NodeOverview struct {
 	StartTime            time.Duration `json:"startTime"`
 }
 
-type nodeOverviewResponseData struct {
+type NodeOverviewResponseData struct {
 	NodeOverview *NodeOverview `json:"overview"`
 }
 
-type NodeOverviewResponse struct {
-	Data  nodeOverviewResponseData
+type NodeOverviewApiResponse struct {
+	Data  NodeOverviewResponseData
 	Error string `json:"error"`
 	Code  string `json:"code"`
 }

--- a/testsCommon/httpClientWrapperStub.go
+++ b/testsCommon/httpClientWrapperStub.go
@@ -1,0 +1,35 @@
+package testsCommon
+
+import (
+	"context"
+	"net/http"
+)
+
+// HTTPClientWrapperStub -
+type HTTPClientWrapperStub struct {
+	GetHTTPCalled  func(ctx context.Context, endpoint string) ([]byte, int, error)
+	PostHTTPCalled func(ctx context.Context, endpoint string, data []byte) ([]byte, int, error)
+}
+
+// GetHTTP -
+func (stub *HTTPClientWrapperStub) GetHTTP(ctx context.Context, endpoint string) ([]byte, int, error) {
+	if stub.GetHTTPCalled != nil {
+		return stub.GetHTTPCalled(ctx, endpoint)
+	}
+
+	return make([]byte, 0), http.StatusOK, nil
+}
+
+// PostHTTP -
+func (stub *HTTPClientWrapperStub) PostHTTP(ctx context.Context, endpoint string, data []byte) ([]byte, int, error) {
+	if stub.PostHTTPCalled != nil {
+		return stub.PostHTTPCalled(ctx, endpoint, data)
+	}
+
+	return make([]byte, 0), http.StatusOK, nil
+}
+
+// IsInterfaceNil -
+func (stub *HTTPClientWrapperStub) IsInterfaceNil() bool {
+	return stub == nil
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an enhanced network status retrieval that delivers a unified node overview endpoint.
  - Added a new method to retrieve the node status in the endpoint provider.

- **Refactor**
  - Streamlined the logic for processing network responses and updated naming conventions for improved API clarity.
  - Added a new HTTP client wrapper stub for flexible testing of HTTP interactions.

- **Tests**
  - Implemented comprehensive tests for the revised network status and proxy functionality.
  - Removed outdated tests related to deprecated methods to maintain test relevance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->