### PR TITLE
[KLC-1408] fix bridge p2p private key decoding

### DIFF
--- a/clients/chain/chain.go
+++ b/clients/chain/chain.go
@@ -6,23 +6,23 @@ import (
 )
 
 const (
-	evmCompatibleChainToMultiversXNameTemplate  = "%sToMultiversX"
-	multiversXToEvmCompatibleChainNameTemplate  = "MultiversXTo%s"
-	baseLogIdTemplate                           = "%sMultiversX-Base"
-	multiversXClientLogIdTemplate               = "%sMultiversX-MultiversXClient"
-	multiversXDataGetterLogIdTemplate           = "%sMultiversX-MultiversXDataGetter"
-	evmCompatibleChainClientLogIdTemplate       = "%sMultiversX-%sClient"
-	multiversXRoleProviderLogIdTemplate         = "%sMultiversX-MultiversXRoleProvider"
-	evmCompatibleChainRoleProviderLogIdTemplate = "%sMultiversX-%sRoleProvider"
-	broadcasterLogIdTemplate                    = "%sMultiversX-Broadcaster"
+	evmCompatibleChainToKleverBlockchainNameTemplate = "%sToKleverBlockchain"
+	multiversXToEvmCompatibleChainNameTemplate       = "KleverBlockchainTo%s"
+	baseLogIdTemplate                                = "%sKleverBlockchain-Base"
+	multiversXClientLogIdTemplate                    = "%sKleverBlockchain-KleverBlockchainClient"
+	multiversXDataGetterLogIdTemplate                = "%sKleverBlockchain-KleverBlockchainDataGetter"
+	evmCompatibleChainClientLogIdTemplate            = "%sKleverBlockchain-%sClient"
+	multiversXRoleProviderLogIdTemplate              = "%sKleverBlockchain-KleverBlockchainRoleProvider"
+	evmCompatibleChainRoleProviderLogIdTemplate      = "%sKleverBlockchain-%sRoleProvider"
+	broadcasterLogIdTemplate                         = "%sKleverBlockchain-Broadcaster"
 )
 
 // Chain defines all the chain supported
 type Chain string
 
 const (
-	// MultiversX is the string representation of the MultiversX chain
-	MultiversX Chain = "msx"
+	// KleverBlockchain is the string representation of the KleverBlockchain chain
+	KleverBlockchain Chain = "klv"
 
 	// Ethereum is the string representation of the Ethereum chain
 	Ethereum Chain = "Ethereum"
@@ -39,13 +39,13 @@ func (c Chain) ToLower() string {
 	return strings.ToLower(string(c))
 }
 
-// EvmCompatibleChainToMultiversXName returns the string using chain value and evmCompatibleChainToMultiversXNameTemplate
-func (c Chain) EvmCompatibleChainToMultiversXName() string {
-	return fmt.Sprintf(evmCompatibleChainToMultiversXNameTemplate, c)
+// EvmCompatibleChainToKleverBlockchainName returns the string using chain value and evmCompatibleChainToKleverBlockchainNameTemplate
+func (c Chain) EvmCompatibleChainToKleverBlockchainName() string {
+	return fmt.Sprintf(evmCompatibleChainToKleverBlockchainNameTemplate, c)
 }
 
-// MultiversXToEvmCompatibleChainName returns the string using chain value and multiversXToEvmCompatibleChainNameTemplate
-func (c Chain) MultiversXToEvmCompatibleChainName() string {
+// KleverBlockchainToEvmCompatibleChainName returns the string using chain value and multiversXToEvmCompatibleChainNameTemplate
+func (c Chain) KleverBlockchainToEvmCompatibleChainName() string {
 	return fmt.Sprintf(multiversXToEvmCompatibleChainNameTemplate, c)
 }
 
@@ -54,13 +54,13 @@ func (c Chain) BaseLogId() string {
 	return fmt.Sprintf(baseLogIdTemplate, c)
 }
 
-// MultiversXClientLogId returns the string using chain value and multiversXClientLogIdTemplate
-func (c Chain) MultiversXClientLogId() string {
+// KleverBlockchainClientLogId returns the string using chain value and multiversXClientLogIdTemplate
+func (c Chain) KleverBlockchainClientLogId() string {
 	return fmt.Sprintf(multiversXClientLogIdTemplate, c)
 }
 
-// MultiversXDataGetterLogId returns the string using chain value and multiversXDataGetterLogIdTemplate
-func (c Chain) MultiversXDataGetterLogId() string {
+// KleverBlockchainDataGetterLogId returns the string using chain value and multiversXDataGetterLogIdTemplate
+func (c Chain) KleverBlockchainDataGetterLogId() string {
 	return fmt.Sprintf(multiversXDataGetterLogIdTemplate, c)
 }
 
@@ -69,8 +69,8 @@ func (c Chain) EvmCompatibleChainClientLogId() string {
 	return fmt.Sprintf(evmCompatibleChainClientLogIdTemplate, c, c)
 }
 
-// MultiversXRoleProviderLogId returns the string using chain value and multiversXRoleProviderLogIdTemplate
-func (c Chain) MultiversXRoleProviderLogId() string {
+// KleverBlockchainRoleProviderLogId returns the string using chain value and multiversXRoleProviderLogIdTemplate
+func (c Chain) KleverBlockchainRoleProviderLogId() string {
 	return fmt.Sprintf(multiversXRoleProviderLogIdTemplate, c)
 }
 

--- a/clients/chain/chain.go
+++ b/clients/chain/chain.go
@@ -7,12 +7,12 @@ import (
 
 const (
 	evmCompatibleChainToKleverBlockchainNameTemplate = "%sToKleverBlockchain"
-	multiversXToEvmCompatibleChainNameTemplate       = "KleverBlockchainTo%s"
+	kleverBlockchainToEvmCompatibleChainNameTemplate = "KleverBlockchainTo%s"
 	baseLogIdTemplate                                = "%sKleverBlockchain-Base"
-	multiversXClientLogIdTemplate                    = "%sKleverBlockchain-KleverBlockchainClient"
-	multiversXDataGetterLogIdTemplate                = "%sKleverBlockchain-KleverBlockchainDataGetter"
+	kleverBlockchainClientLogIdTemplate              = "%sKleverBlockchain-KleverBlockchainClient"
+	kleverBlockchainDataGetterLogIdTemplate          = "%sKleverBlockchain-KleverBlockchainDataGetter"
 	evmCompatibleChainClientLogIdTemplate            = "%sKleverBlockchain-%sClient"
-	multiversXRoleProviderLogIdTemplate              = "%sKleverBlockchain-KleverBlockchainRoleProvider"
+	kleverBlockchainRoleProviderLogIdTemplate        = "%sKleverBlockchain-KleverBlockchainRoleProvider"
 	evmCompatibleChainRoleProviderLogIdTemplate      = "%sKleverBlockchain-%sRoleProvider"
 	broadcasterLogIdTemplate                         = "%sKleverBlockchain-Broadcaster"
 )
@@ -44,9 +44,9 @@ func (c Chain) EvmCompatibleChainToKleverBlockchainName() string {
 	return fmt.Sprintf(evmCompatibleChainToKleverBlockchainNameTemplate, c)
 }
 
-// KleverBlockchainToEvmCompatibleChainName returns the string using chain value and multiversXToEvmCompatibleChainNameTemplate
+// KleverBlockchainToEvmCompatibleChainName returns the string using chain value and kleverBlockchainToEvmCompatibleChainNameTemplate
 func (c Chain) KleverBlockchainToEvmCompatibleChainName() string {
-	return fmt.Sprintf(multiversXToEvmCompatibleChainNameTemplate, c)
+	return fmt.Sprintf(kleverBlockchainToEvmCompatibleChainNameTemplate, c)
 }
 
 // BaseLogId returns the string using chain value and baseLogIdTemplate
@@ -54,14 +54,14 @@ func (c Chain) BaseLogId() string {
 	return fmt.Sprintf(baseLogIdTemplate, c)
 }
 
-// KleverBlockchainClientLogId returns the string using chain value and multiversXClientLogIdTemplate
+// KleverBlockchainClientLogId returns the string using chain value and kleverBlockchainClientLogIdTemplate
 func (c Chain) KleverBlockchainClientLogId() string {
-	return fmt.Sprintf(multiversXClientLogIdTemplate, c)
+	return fmt.Sprintf(kleverBlockchainClientLogIdTemplate, c)
 }
 
-// KleverBlockchainDataGetterLogId returns the string using chain value and multiversXDataGetterLogIdTemplate
+// KleverBlockchainDataGetterLogId returns the string using chain value and kleverBlockchainDataGetterLogIdTemplate
 func (c Chain) KleverBlockchainDataGetterLogId() string {
-	return fmt.Sprintf(multiversXDataGetterLogIdTemplate, c)
+	return fmt.Sprintf(kleverBlockchainDataGetterLogIdTemplate, c)
 }
 
 // EvmCompatibleChainClientLogId returns the string using chain value and evmCompatibleChainClientLogIdTemplate
@@ -69,9 +69,9 @@ func (c Chain) EvmCompatibleChainClientLogId() string {
 	return fmt.Sprintf(evmCompatibleChainClientLogIdTemplate, c, c)
 }
 
-// KleverBlockchainRoleProviderLogId returns the string using chain value and multiversXRoleProviderLogIdTemplate
+// KleverBlockchainRoleProviderLogId returns the string using chain value and kleverBlockchainRoleProviderLogIdTemplate
 func (c Chain) KleverBlockchainRoleProviderLogId() string {
-	return fmt.Sprintf(multiversXRoleProviderLogIdTemplate, c)
+	return fmt.Sprintf(kleverBlockchainRoleProviderLogIdTemplate, c)
 }
 
 // EvmCompatibleChainRoleProviderLogId returns the string using chain value and evmCompatibleChainRoleProviderLogIdTemplate

--- a/clients/chain/chain_test.go
+++ b/clients/chain/chain_test.go
@@ -6,53 +6,53 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_ethToMultiversXName(t *testing.T) {
-	assert.Equal(t, "EthereumToMultiversX", Ethereum.EvmCompatibleChainToMultiversXName())
-	assert.Equal(t, "BscToMultiversX", Bsc.EvmCompatibleChainToMultiversXName())
+func Test_ethToKleverBlockchainName(t *testing.T) {
+	assert.Equal(t, "EthereumToKleverBlockchain", Ethereum.EvmCompatibleChainToKleverBlockchainName())
+	assert.Equal(t, "BscToKleverBlockchain", Bsc.EvmCompatibleChainToKleverBlockchainName())
 }
 
 func Test_multiversXToEthName(t *testing.T) {
-	assert.Equal(t, "MultiversXToEthereum", Ethereum.MultiversXToEvmCompatibleChainName())
-	assert.Equal(t, "MultiversXToBsc", Bsc.MultiversXToEvmCompatibleChainName())
+	assert.Equal(t, "KleverBlockchainToEthereum", Ethereum.KleverBlockchainToEvmCompatibleChainName())
+	assert.Equal(t, "KleverBlockchainToBsc", Bsc.KleverBlockchainToEvmCompatibleChainName())
 }
 
 func Test_baseLogId(t *testing.T) {
-	assert.Equal(t, "EthereumMultiversX-Base", Ethereum.BaseLogId())
-	assert.Equal(t, "BscMultiversX-Base", Bsc.BaseLogId())
+	assert.Equal(t, "EthereumKleverBlockchain-Base", Ethereum.BaseLogId())
+	assert.Equal(t, "BscKleverBlockchain-Base", Bsc.BaseLogId())
 }
 
 func Test_multiversXClientLogId(t *testing.T) {
-	assert.Equal(t, "EthereumMultiversX-MultiversXClient", Ethereum.MultiversXClientLogId())
-	assert.Equal(t, "BscMultiversX-MultiversXClient", Bsc.MultiversXClientLogId())
+	assert.Equal(t, "EthereumKleverBlockchain-KleverBlockchainClient", Ethereum.KleverBlockchainClientLogId())
+	assert.Equal(t, "BscKleverBlockchain-KleverBlockchainClient", Bsc.KleverBlockchainClientLogId())
 }
 
 func Test_multiversXDataGetterLogId(t *testing.T) {
-	assert.Equal(t, "EthereumMultiversX-MultiversXDataGetter", Ethereum.MultiversXDataGetterLogId())
-	assert.Equal(t, "BscMultiversX-MultiversXDataGetter", Bsc.MultiversXDataGetterLogId())
+	assert.Equal(t, "EthereumKleverBlockchain-KleverBlockchainDataGetter", Ethereum.KleverBlockchainDataGetterLogId())
+	assert.Equal(t, "BscKleverBlockchain-KleverBlockchainDataGetter", Bsc.KleverBlockchainDataGetterLogId())
 }
 
 func Test_ethClientLogId(t *testing.T) {
-	assert.Equal(t, "EthereumMultiversX-EthereumClient", Ethereum.EvmCompatibleChainClientLogId())
-	assert.Equal(t, "BscMultiversX-BscClient", Bsc.EvmCompatibleChainClientLogId())
+	assert.Equal(t, "EthereumKleverBlockchain-EthereumClient", Ethereum.EvmCompatibleChainClientLogId())
+	assert.Equal(t, "BscKleverBlockchain-BscClient", Bsc.EvmCompatibleChainClientLogId())
 }
 
 func Test_multiversXRoleProviderLogId(t *testing.T) {
-	assert.Equal(t, "EthereumMultiversX-MultiversXRoleProvider", Ethereum.MultiversXRoleProviderLogId())
-	assert.Equal(t, "BscMultiversX-MultiversXRoleProvider", Bsc.MultiversXRoleProviderLogId())
+	assert.Equal(t, "EthereumKleverBlockchain-KleverBlockchainRoleProvider", Ethereum.KleverBlockchainRoleProviderLogId())
+	assert.Equal(t, "BscKleverBlockchain-KleverBlockchainRoleProvider", Bsc.KleverBlockchainRoleProviderLogId())
 }
 
 func Test_ethRoleProviderLogId(t *testing.T) {
-	assert.Equal(t, "EthereumMultiversX-EthereumRoleProvider", Ethereum.EvmCompatibleChainRoleProviderLogId())
-	assert.Equal(t, "BscMultiversX-BscRoleProvider", Bsc.EvmCompatibleChainRoleProviderLogId())
+	assert.Equal(t, "EthereumKleverBlockchain-EthereumRoleProvider", Ethereum.EvmCompatibleChainRoleProviderLogId())
+	assert.Equal(t, "BscKleverBlockchain-BscRoleProvider", Bsc.EvmCompatibleChainRoleProviderLogId())
 }
 
 func Test_broadcasterLogId(t *testing.T) {
-	assert.Equal(t, "EthereumMultiversX-Broadcaster", Ethereum.BroadcasterLogId())
-	assert.Equal(t, "BscMultiversX-Broadcaster", Bsc.BroadcasterLogId())
+	assert.Equal(t, "EthereumKleverBlockchain-Broadcaster", Ethereum.BroadcasterLogId())
+	assert.Equal(t, "BscKleverBlockchain-Broadcaster", Bsc.BroadcasterLogId())
 }
 
 func TestToLower(t *testing.T) {
-	assert.Equal(t, "msx", MultiversX.ToLower())
+	assert.Equal(t, "klv", KleverBlockchain.ToLower())
 	assert.Equal(t, "ethereum", Ethereum.ToLower())
 	assert.Equal(t, "bsc", Bsc.ToLower())
 }

--- a/clients/chain/chain_test.go
+++ b/clients/chain/chain_test.go
@@ -11,7 +11,7 @@ func Test_ethToKleverBlockchainName(t *testing.T) {
 	assert.Equal(t, "BscToKleverBlockchain", Bsc.EvmCompatibleChainToKleverBlockchainName())
 }
 
-func Test_multiversXToEthName(t *testing.T) {
+func Test_kleverBlockchainToEthName(t *testing.T) {
 	assert.Equal(t, "KleverBlockchainToEthereum", Ethereum.KleverBlockchainToEvmCompatibleChainName())
 	assert.Equal(t, "KleverBlockchainToBsc", Bsc.KleverBlockchainToEvmCompatibleChainName())
 }
@@ -21,12 +21,12 @@ func Test_baseLogId(t *testing.T) {
 	assert.Equal(t, "BscKleverBlockchain-Base", Bsc.BaseLogId())
 }
 
-func Test_multiversXClientLogId(t *testing.T) {
+func Test_kleverBlockchainClientLogId(t *testing.T) {
 	assert.Equal(t, "EthereumKleverBlockchain-KleverBlockchainClient", Ethereum.KleverBlockchainClientLogId())
 	assert.Equal(t, "BscKleverBlockchain-KleverBlockchainClient", Bsc.KleverBlockchainClientLogId())
 }
 
-func Test_multiversXDataGetterLogId(t *testing.T) {
+func Test_kleverBlockchainDataGetterLogId(t *testing.T) {
 	assert.Equal(t, "EthereumKleverBlockchain-KleverBlockchainDataGetter", Ethereum.KleverBlockchainDataGetterLogId())
 	assert.Equal(t, "BscKleverBlockchain-KleverBlockchainDataGetter", Bsc.KleverBlockchainDataGetterLogId())
 }
@@ -36,7 +36,7 @@ func Test_ethClientLogId(t *testing.T) {
 	assert.Equal(t, "BscKleverBlockchain-BscClient", Bsc.EvmCompatibleChainClientLogId())
 }
 
-func Test_multiversXRoleProviderLogId(t *testing.T) {
+func Test_kleverBlockchainRoleProviderLogId(t *testing.T) {
 	assert.Equal(t, "EthereumKleverBlockchain-KleverBlockchainRoleProvider", Ethereum.KleverBlockchainRoleProviderLogId())
 	assert.Equal(t, "BscKleverBlockchain-KleverBlockchainRoleProvider", Bsc.KleverBlockchainRoleProviderLogId())
 }

--- a/cmd/bridge/config/config.toml
+++ b/cmd/bridge/config/config.toml
@@ -52,7 +52,7 @@
 [P2P]
     Port = "10010"
     InitialPeerList = []
-    ProtocolID = "/erd/relay/1.0.0"
+    ProtocolID = "/klv/relay/1.0.0"
     [P2P.Transports]
         QUICAddress = "" # optional QUIC address. If this transport should be activated, should be in this format: /ip4/0.0.0.0/udp/%d/quic-v1
         WebSocketAddress = "" # optional WebSocket address. If this transport should be activated, should be in this format: /ip4/0.0.0.0/tcp/%d/ws
@@ -122,8 +122,8 @@
             Type = "LRU"
         [P2P.AntifloodConfig.Topic]
             DefaultMaxMessagesPerSec = 300 # default number of messages per interval for a topic
-            MaxMessages = [{ Topic = "EthereumToKleverChain_join", NumMessagesPerSec = 100 },
-                           { Topic = "EthereumToKleverChain_sign", NumMessagesPerSec = 100 }]
+            MaxMessages = [{ Topic = "EthereumToKleverBlockchain_join", NumMessagesPerSec = 100 },
+                           { Topic = "EthereumToKleverBlockchain_sign", NumMessagesPerSec = 100 }]
 
 [Relayer]
     [Relayer.Marshalizer]
@@ -144,11 +144,11 @@
             MaxOpenFiles = 10
 
 [StateMachine]
-    [StateMachine.EthereumToKleverChain]
+    [StateMachine.EthereumToKleverBlockchain]
         StepDurationInMillis = 12000 #12 seconds
         IntervalForLeaderInSeconds = 120 #2 minutes
 
-    [StateMachine.KleverChainToEthereum]
+    [StateMachine.KleverBlockchainToEthereum]
         StepDurationInMillis = 12000 #12 seconds
         IntervalForLeaderInSeconds = 720 #12 minutes
 

--- a/executors/kleverchain/module/scCallsModule.go
+++ b/executors/kleverchain/module/scCallsModule.go
@@ -1,6 +1,8 @@
 package module
 
 import (
+	"encoding/hex"
+	"fmt"
 	"time"
 
 	"github.com/klever-io/klever-go/tools"
@@ -49,9 +51,14 @@ func NewScCallsModule(cfg config.ScCallsModuleConfig, log logger.Logger, chClose
 	}
 
 	// Public key not used in this case
-	kleverChainPrivateKeyBytes, _, err := tools.LoadSkPkFromPemFile(cfg.PrivateKeyFile, 0, "")
+	encodedSk, _, err := tools.LoadSkPkFromPemFile(cfg.PrivateKeyFile, 0, "")
 	if err != nil {
 		return nil, err
+	}
+
+	kleverChainPrivateKeyBytes, err := hex.DecodeString(string(encodedSk))
+	if err != nil {
+		return nil, fmt.Errorf("%w for encoded secret key", err)
 	}
 
 	privateKey, err := keyGen.PrivateKeyFromByteArray(kleverChainPrivateKeyBytes)

--- a/factory/ethKleverBridgeComponents.go
+++ b/factory/ethKleverBridgeComponents.go
@@ -120,7 +120,7 @@ func NewEthKleverBridgeComponents(args ArgsEthereumToKleverBridge) (*ethKleverBr
 		return nil, err
 	}
 	evmCompatibleChain := args.Configs.GeneralConfig.Eth.Chain
-	ethtokleverName := evmCompatibleChain.EvmCompatibleChainToMultiversXName()
+	ethtokleverName := evmCompatibleChain.EvmCompatibleChainToKleverBlockchainName()
 	baseLogId := evmCompatibleChain.BaseLogId()
 	components := &ethKleverBridgeComponents{
 		baseLogger:           core.NewLoggerWithIdentifier(logger.GetOrCreate(ethtokleverName), baseLogId),
@@ -272,7 +272,7 @@ func (components *ethKleverBridgeComponents) createKleverKeysAndAddresses(chainC
 }
 
 func (components *ethKleverBridgeComponents) createDataGetter() error {
-	multiversXDataGetterLogId := components.evmCompatibleChain.MultiversXDataGetterLogId()
+	multiversXDataGetterLogId := components.evmCompatibleChain.KleverBlockchainDataGetterLogId()
 	argsKLVClientDataGetter := klever.ArgsKLVClientDataGetter{
 		MultisigContractAddress: components.kleverMultisigContractAddress,
 		SafeContractAddress:     components.kleverSafeContractAddress,
@@ -293,7 +293,7 @@ func (components *ethKleverBridgeComponents) createMultiversXClient(args ArgsEth
 	if err != nil {
 		return err
 	}
-	multiversXClientLogId := components.evmCompatibleChain.MultiversXClientLogId()
+	multiversXClientLogId := components.evmCompatibleChain.KleverBlockchainClientLogId()
 
 	clientArgs := klever.ClientArgs{
 		GasMapConfig:                 chainConfigs.GasMap,
@@ -352,7 +352,7 @@ func (components *ethKleverBridgeComponents) createEthereumClient(args ArgsEther
 	}
 
 	broadcasterLogId := components.evmCompatibleChain.BroadcasterLogId()
-	ethtokleverName := components.evmCompatibleChain.EvmCompatibleChainToMultiversXName()
+	ethtokleverName := components.evmCompatibleChain.EvmCompatibleChainToKleverBlockchainName()
 	argsBroadcaster := p2p.ArgsBroadcaster{
 		Messenger:              args.Messenger,
 		Log:                    core.NewLoggerWithIdentifier(logger.GetOrCreate(broadcasterLogId), broadcasterLogId),
@@ -417,7 +417,7 @@ func (components *ethKleverBridgeComponents) createEthereumClient(args ArgsEther
 
 func (components *ethKleverBridgeComponents) createKleverRoleProvider(args ArgsEthereumToKleverBridge) error {
 	configs := args.Configs.GeneralConfig
-	multiversXRoleProviderLogId := components.evmCompatibleChain.MultiversXRoleProviderLogId()
+	multiversXRoleProviderLogId := components.evmCompatibleChain.KleverBlockchainRoleProviderLogId()
 	log := core.NewLoggerWithIdentifier(logger.GetOrCreate(multiversXRoleProviderLogId), multiversXRoleProviderLogId)
 
 	argsRoleProvider := roleproviders.ArgsMultiversXRoleProvider{
@@ -433,7 +433,7 @@ func (components *ethKleverBridgeComponents) createKleverRoleProvider(args ArgsE
 
 	argsPollingHandler := polling.ArgsPollingHandler{
 		Log:              log,
-		Name:             "MultiversX role provider",
+		Name:             "KleverBlockchain role provider",
 		PollingInterval:  time.Duration(configs.Relayer.RoleProvider.PollingIntervalInMillis) * time.Millisecond,
 		PollingWhenError: pollingDurationOnError,
 		Executor:         components.kleverRoleProvider,
@@ -485,7 +485,7 @@ func (components *ethKleverBridgeComponents) createEthereumRoleProvider(args Arg
 }
 
 func (components *ethKleverBridgeComponents) createEthereumToMultiversXBridge(args ArgsEthereumToKleverBridge) error {
-	ethtokleverName := components.evmCompatibleChain.EvmCompatibleChainToMultiversXName()
+	ethtokleverName := components.evmCompatibleChain.EvmCompatibleChainToKleverBlockchainName()
 	log := core.NewLoggerWithIdentifier(logger.GetOrCreate(ethtokleverName), ethtokleverName)
 
 	configs, found := args.Configs.GeneralConfig.StateMachine[ethtokleverName]
@@ -554,7 +554,7 @@ func (components *ethKleverBridgeComponents) createEthereumToMultiversXBridge(ar
 }
 
 func (components *ethKleverBridgeComponents) createMultiversXToEthereumBridge(args ArgsEthereumToKleverBridge) error {
-	multiversXToEthName := components.evmCompatibleChain.MultiversXToEvmCompatibleChainName()
+	multiversXToEthName := components.evmCompatibleChain.KleverBlockchainToEvmCompatibleChainName()
 	log := core.NewLoggerWithIdentifier(logger.GetOrCreate(multiversXToEthName), multiversXToEthName)
 
 	configs, found := args.Configs.GeneralConfig.StateMachine[multiversXToEthName]
@@ -672,7 +672,7 @@ func (components *ethKleverBridgeComponents) createBalanceValidator() (ethklever
 }
 
 func (components *ethKleverBridgeComponents) createEthereumToMultiversXStateMachine() error {
-	ethtokleverName := components.evmCompatibleChain.EvmCompatibleChainToMultiversXName()
+	ethtokleverName := components.evmCompatibleChain.EvmCompatibleChainToKleverBlockchainName()
 	log := core.NewLoggerWithIdentifier(logger.GetOrCreate(ethtokleverName), ethtokleverName)
 
 	argsStateMachine := stateMachine.ArgsStateMachine{
@@ -709,7 +709,7 @@ func (components *ethKleverBridgeComponents) createEthereumToMultiversXStateMach
 }
 
 func (components *ethKleverBridgeComponents) createMultiversXToEthereumStateMachine() error {
-	multiversXToEthName := components.evmCompatibleChain.MultiversXToEvmCompatibleChainName()
+	multiversXToEthName := components.evmCompatibleChain.KleverBlockchainToEvmCompatibleChainName()
 	log := core.NewLoggerWithIdentifier(logger.GetOrCreate(multiversXToEthName), multiversXToEthName)
 
 	argsStateMachine := stateMachine.ArgsStateMachine{

--- a/factory/ethKleverBridgeComponents.go
+++ b/factory/ethKleverBridgeComponents.go
@@ -2,6 +2,7 @@ package factory
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"sync"
@@ -235,9 +236,14 @@ func checkArgsEthereumToKleverBridge(args ArgsEthereumToKleverBridge) error {
 }
 
 func (components *ethKleverBridgeComponents) createKleverKeysAndAddresses(chainConfigs config.KleverConfig) error {
-	kleverPrivateKeyBytes, pbkString, err := tools.LoadSkPkFromPemFile(chainConfigs.PrivateKeyFile, 0, "")
+	encodedSk, pbkString, err := tools.LoadSkPkFromPemFile(chainConfigs.PrivateKeyFile, 0, "")
 	if err != nil {
 		return err
+	}
+
+	kleverPrivateKeyBytes, err := hex.DecodeString(string(encodedSk))
+	if err != nil {
+		return fmt.Errorf("%w for encoded secret key", err)
 	}
 
 	components.kleverRelayerPrivateKey, err = keyGen.PrivateKeyFromByteArray(kleverPrivateKeyBytes)

--- a/factory/ethKleverBridgeComponents_test.go
+++ b/factory/ethKleverBridgeComponents_test.go
@@ -76,8 +76,8 @@ func createMockEthKleverBridgeArgs() ArgsEthereumToKleverBridge {
 			},
 		},
 		StateMachine: map[string]config.ConfigStateMachine{
-			"EthereumToMultiversX": stateMachineConfig,
-			"MultiversXToEthereum": stateMachineConfig,
+			"EthereumToKleverBlockchain": stateMachineConfig,
+			"KleverBlockchainToEthereum": stateMachineConfig,
 		},
 	}
 	configs := config.Configs{
@@ -154,7 +154,7 @@ func TestNewEthKleverBridgeComponents(t *testing.T) {
 		assert.Equal(t, errNilErc20ContractsHolder, err)
 		assert.Nil(t, components)
 	})
-	t.Run("err on createMultiversXKeysAndAddresses, empty pk file", func(t *testing.T) {
+	t.Run("err on createKleverBlockchainKeysAndAddresses, empty pk file", func(t *testing.T) {
 		t.Parallel()
 		args := createMockEthKleverBridgeArgs()
 		args.Configs.GeneralConfig.Klever.PrivateKeyFile = ""
@@ -163,7 +163,7 @@ func TestNewEthKleverBridgeComponents(t *testing.T) {
 		assert.NotNil(t, err)
 		assert.Nil(t, components)
 	})
-	t.Run("err on createMultiversXKeysAndAddresses, empty multisig address", func(t *testing.T) {
+	t.Run("err on createKleverBlockchainKeysAndAddresses, empty multisig address", func(t *testing.T) {
 		t.Parallel()
 		args := createMockEthKleverBridgeArgs()
 		args.Configs.GeneralConfig.Klever.MultisigContractAddress = ""
@@ -172,7 +172,7 @@ func TestNewEthKleverBridgeComponents(t *testing.T) {
 		assert.NotNil(t, err)
 		assert.Nil(t, components)
 	})
-	t.Run("err on createMultiversXClient", func(t *testing.T) {
+	t.Run("err on createKleverBlockchainClient", func(t *testing.T) {
 		t.Parallel()
 		args := createMockEthKleverBridgeArgs()
 		args.Configs.GeneralConfig.Klever.GasMap = config.KleverGasMapConfig{}
@@ -181,7 +181,7 @@ func TestNewEthKleverBridgeComponents(t *testing.T) {
 		assert.NotNil(t, err)
 		assert.Nil(t, components)
 	})
-	t.Run("err on createMultiversXRoleProvider", func(t *testing.T) {
+	t.Run("err on createKleverBlockchainRoleProvider", func(t *testing.T) {
 		t.Parallel()
 		args := createMockEthKleverBridgeArgs()
 		args.Configs.GeneralConfig.Relayer.RoleProvider.PollingIntervalInMillis = 0
@@ -215,7 +215,7 @@ func TestNewEthKleverBridgeComponents(t *testing.T) {
 
 		components, err := NewEthKleverBridgeComponents(args)
 		assert.True(t, errors.Is(err, errMissingConfig))
-		assert.True(t, strings.Contains(err.Error(), args.Configs.GeneralConfig.Eth.Chain.EvmCompatibleChainToMultiversXName()))
+		assert.True(t, strings.Contains(err.Error(), args.Configs.GeneralConfig.Eth.Chain.EvmCompatibleChainToKleverBlockchainName()))
 		assert.Nil(t, components)
 	})
 	t.Run("invalid time for bootstrap", func(t *testing.T) {


### PR DESCRIPTION
When decoding the pem file, the private key read wasn’t in the proper format, making it unusable, this PR has the objective to fix this issue, and make the private key usable by the p2p library.

## Changes
- Fix private key decoding
- Updated constant names used in p2p communication

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated all blockchain references and communication settings to align with the new KleverBlockchain integration for a more consistent experience.
  - Streamlined secure key handling with enhanced error messages for improved troubleshooting.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->