### PR TITLE
[KLC-1933] Bridged tokens decimal conversion

### DIFF
--- a/bridges/ethKC/interface.go
+++ b/bridges/ethKC/interface.go
@@ -26,6 +26,7 @@ type KCClient interface {
 	GetLastExecutedEthTxID(ctx context.Context) (uint64, error)
 	GetLastKCBatchID(ctx context.Context) (uint64, error)
 	GetCurrentNonce(ctx context.Context) (uint64, error)
+	ConvertEthToKdaAmount(ctx context.Context, token []byte, amount *big.Int) (*big.Int, error)
 
 	ProposeSetStatus(ctx context.Context, batch *bridgeCore.TransferBatch) (string, error)
 	ProposeTransfer(ctx context.Context, batch *bridgeCore.TransferBatch) (string, error)

--- a/clients/balanceValidator/balanceValidator.go
+++ b/clients/balanceValidator/balanceValidator.go
@@ -104,17 +104,26 @@ func (validator *balanceValidator) CheckToken(ctx context.Context, ethToken comm
 		return err
 	}
 
+	// Convert ethAmount (ETH decimals) to KDA decimals for comparison
+	// Since KC balances are tracked in KDA decimals, we need to convert ETH amount to match
+	ethAmountInKdaDecimals, err := validator.kcClient.ConvertEthToKdaAmount(ctx, kdaToken, ethAmount)
+	if err != nil {
+		return err
+	}
+
 	validator.log.Debug("balanceValidator.CheckToken",
 		"ERC20 token", ethToken.String(),
-		"ERC20 balance", ethAmount.String(),
+		"ERC20 balance (ETH decimals)", ethAmount.String(),
+		"ERC20 balance (KDA decimals)", ethAmountInKdaDecimals.String(),
 		"KDA token", kdaToken,
 		"KDA balance", kdaAmount.String(),
 		"amount", amount.String(),
 	)
 
-	if ethAmount.Cmp(kdaAmount) != 0 {
-		return fmt.Errorf("%w, balance for ERC20 token %s is %s and the balance for KDA token %s is %s, direction %s",
-			ErrBalanceMismatch, ethToken.String(), ethAmount.String(), kdaToken, kdaAmount.String(), direction)
+	// Compare both amounts in KDA decimals
+	if ethAmountInKdaDecimals.Cmp(kdaAmount) != 0 {
+		return fmt.Errorf("%w, balance for ERC20 token %s is %s (converted: %s) and the balance for KDA token %s is %s, direction %s",
+			ErrBalanceMismatch, ethToken.String(), ethAmount.String(), ethAmountInKdaDecimals.String(), kdaToken, kdaAmount.String(), direction)
 	}
 	return nil
 }
@@ -216,6 +225,7 @@ func (validator *balanceValidator) computeKdaAmount(
 	isMintBurn bool,
 	isNative bool,
 ) (*big.Int, error) {
+	// kdaAmountInPendingBatches is already in KDA decimals (uses ConvertedAmount from batch)
 	kdaAmountInPendingBatches, err := validator.getTotalTransferAmountInPendingKlvBatches(ctx, token)
 	if err != nil {
 		return nil, err
@@ -268,6 +278,18 @@ func getTotalAmountFromBatch(batch *bridgeCore.TransferBatch, token []byte) *big
 	return amount
 }
 
+// getConvertedTotalAmountFromBatch uses ConvertedAmount (KDA decimals) for KC-originated batches
+func getConvertedTotalAmountFromBatch(batch *bridgeCore.TransferBatch, token []byte) *big.Int {
+	amount := big.NewInt(0)
+	for _, deposit := range batch.Deposits {
+		if bytes.Equal(deposit.SourceTokenBytes, token) {
+			amount.Add(amount, deposit.ConvertedAmount)
+		}
+	}
+
+	return amount
+}
+
 func (validator *balanceValidator) getTotalTransferAmountInPendingKlvBatches(ctx context.Context, kdaToken []byte) (*big.Int, error) {
 	batchID, err := validator.kcClient.GetLastKCBatchID(ctx)
 	if err != nil {
@@ -293,7 +315,8 @@ func (validator *balanceValidator) getTotalTransferAmountInPendingKlvBatches(ctx
 			return amount, nil
 		}
 
-		amountFromBatch := getTotalAmountFromBatch(batch, kdaToken)
+		// Use ConvertedAmount (KDA decimals) to match KC balances which are also in KDA decimals
+		amountFromBatch := getConvertedTotalAmountFromBatch(batch, kdaToken)
 		amount.Add(amount, amountFromBatch)
 		batchID-- // go to the previous batch
 	}

--- a/clients/balanceValidator/balanceValidator_test.go
+++ b/clients/balanceValidator/balanceValidator_test.go
@@ -1553,6 +1553,7 @@ func applyDummyFromKlvDepositsToBatch(cfg testConfiguration, batch *bridgeCore.T
 				batch.Deposits = append(batch.Deposits, &bridgeCore.DepositTransfer{
 					Nonce:            depositCounter,
 					Amount:           big.NewInt(0).Set(deposit),
+					ConvertedAmount:  big.NewInt(0).Set(deposit),
 					SourceTokenBytes: kdaToken,
 				})
 			}
@@ -1570,6 +1571,7 @@ func applyDummyFromEthDepositsToBatch(cfg testConfiguration, batch *bridgeCore.T
 				batch.Deposits = append(batch.Deposits, &bridgeCore.DepositTransfer{
 					Nonce:            depositCounter,
 					Amount:           big.NewInt(0).Set(deposit),
+					ConvertedAmount:  big.NewInt(0).Set(deposit),
 					SourceTokenBytes: ethToken.Bytes(),
 				})
 			}

--- a/clients/balanceValidator/interface.go
+++ b/clients/balanceValidator/interface.go
@@ -20,6 +20,7 @@ type KCClient interface {
 	MintBalances(ctx context.Context, token []byte) (*big.Int, error)
 	BurnBalances(ctx context.Context, token []byte) (*big.Int, error)
 	CheckRequiredBalance(ctx context.Context, token []byte, value *big.Int) error
+	ConvertEthToKdaAmount(ctx context.Context, token []byte, amount *big.Int) (*big.Int, error)
 	IsInterfaceNil() bool
 }
 

--- a/clients/errors.go
+++ b/clients/errors.go
@@ -38,4 +38,7 @@ var (
 
 	// ErrNilCryptoHandler signals that a nil crypto handler was provided
 	ErrNilCryptoHandler = errors.New("nil crypto handler")
+
+	// ErrMissingConvertedAmount signals that the converted amount for a batch deposit is missing
+	ErrMissingConvertedAmount = errors.New("nil converted amount in batch deposit")
 )

--- a/clients/klever/client_test.go
+++ b/clients/klever/client_test.go
@@ -85,7 +85,8 @@ func createMockPendingBatchBytes(numDeposits int) [][]byte {
 		generatorByte++
 		pendingBatchBytes = append(pendingBatchBytes, bytes.Repeat([]byte{generatorByte}, 32)) // token
 
-		pendingBatchBytes = append(pendingBatchBytes, big.NewInt(int64((i+1)*10000)).Bytes())
+		pendingBatchBytes = append(pendingBatchBytes, big.NewInt(int64((i+1)*10000)).Bytes()) // amount (ETH decimals)
+		pendingBatchBytes = append(pendingBatchBytes, big.NewInt(int64((i+1)*10000)).Bytes()) // converted_amount (KDA decimals)
 	}
 
 	return pendingBatchBytes
@@ -271,7 +272,7 @@ func TestClient_GetPendingBatch(t *testing.T) {
 
 		assert.Nil(t, batch)
 		assert.True(t, errors.Is(err, errInvalidNumberOfArguments))
-		assert.True(t, strings.Contains(err.Error(), "got 12 argument(s)"))
+		assert.True(t, strings.Contains(err.Error(), "got 14 argument(s)"))
 
 		args.Proxy = createMockProxy([][]byte{{1}})
 		c, _ = NewClient(args)
@@ -302,7 +303,7 @@ func TestClient_GetPendingBatch(t *testing.T) {
 
 		args := createMockClientArgs()
 		buff := createMockPendingBatchBytes(2)
-		buff[8] = bytes.Repeat([]byte{1}, 32)
+		buff[9] = bytes.Repeat([]byte{1}, 32)
 		args.Proxy = createMockProxy(buff)
 
 		c, _ := NewClient(args)
@@ -358,6 +359,7 @@ func TestClient_GetPendingBatch(t *testing.T) {
 					DestinationTokenBytes: append([]byte("converted_"), tokenBytes1...),
 					DisplayableToken:      string(tokenBytes1),
 					Amount:                big.NewInt(10000),
+					ConvertedAmount:       big.NewInt(10000),
 				},
 				{
 					Nonce:                 5001,
@@ -369,6 +371,7 @@ func TestClient_GetPendingBatch(t *testing.T) {
 					DestinationTokenBytes: append([]byte("converted_"), tokenBytes2...),
 					DisplayableToken:      string(tokenBytes2),
 					Amount:                big.NewInt(20000),
+					ConvertedAmount:       big.NewInt(20000),
 				},
 			},
 			Statuses: make([]byte, 2),
@@ -428,7 +431,7 @@ func TestClient_GetBatch(t *testing.T) {
 
 		assert.Nil(t, batch)
 		assert.True(t, errors.Is(err, errInvalidNumberOfArguments))
-		assert.True(t, strings.Contains(err.Error(), "got 12 argument(s)"))
+		assert.True(t, strings.Contains(err.Error(), "got 14 argument(s)"))
 
 		args.Proxy = createMockProxy([][]byte{{1}})
 		c, _ = NewClient(args)
@@ -459,7 +462,7 @@ func TestClient_GetBatch(t *testing.T) {
 
 		args := createMockClientArgs()
 		buff := createMockPendingBatchBytes(2)
-		buff[8] = bytes.Repeat([]byte{1}, 32)
+		buff[9] = bytes.Repeat([]byte{1}, 32)
 		args.Proxy = createMockProxy(buff)
 
 		c, _ := NewClient(args)
@@ -515,6 +518,7 @@ func TestClient_GetBatch(t *testing.T) {
 					DestinationTokenBytes: append([]byte("converted_"), tokenBytes1...),
 					DisplayableToken:      string(tokenBytes1),
 					Amount:                big.NewInt(10000),
+					ConvertedAmount:       big.NewInt(10000),
 				},
 				{
 					Nonce:                 5001,
@@ -526,6 +530,7 @@ func TestClient_GetBatch(t *testing.T) {
 					DestinationTokenBytes: append([]byte("converted_"), tokenBytes2...),
 					DisplayableToken:      string(tokenBytes2),
 					Amount:                big.NewInt(20000),
+					ConvertedAmount:       big.NewInt(20000),
 				},
 			},
 			Statuses: make([]byte, 2),
@@ -776,6 +781,7 @@ func depositToString(dt *bridgeCore.DepositTransfer) string {
 	result = result + "@" + hex.EncodeToString(dt.ToBytes)
 	result = result + "@" + hex.EncodeToString(dt.DestinationTokenBytes)
 	result = result + "@" + hex.EncodeToString(dt.Amount.Bytes())
+	result = result + "@" + hex.EncodeToString(dt.ConvertedAmount.Bytes())
 	result = result + "@" + hex.EncodeToString(big.NewInt(0).SetUint64(dt.Nonce).Bytes())
 	result = result + "@" + hex.EncodeToString(dt.Data)
 

--- a/clients/klever/klvClientDataGetter.go
+++ b/clients/klever/klvClientDataGetter.go
@@ -43,6 +43,7 @@ const (
 	getBurnBalances                                           = "getBurnBalances"
 	getAllKnownTokens                                         = "getAllKnownTokens"
 	getLastBatchId                                            = "getLastBatchId"
+	convertEthToKdaAmountFuncName                             = "convertEthToKdaAmount"
 )
 
 // ArgsklvClientDataGetter is the arguments DTO used in the NewklvClientDataGetter constructor
@@ -487,6 +488,7 @@ func (dataGetter *klvClientDataGetter) addBatchInfo(builder builders.VMQueryBuil
 			ArgBytes(dt.ToBytes).
 			ArgBytes(dt.DestinationTokenBytes).
 			ArgBigInt(dt.Amount).
+			ArgBigInt(dt.ConvertedAmount).
 			ArgInt64(int64(dt.Nonce)).
 			ArgBytes(dt.Data)
 	}
@@ -514,6 +516,14 @@ func (dataGetter *klvClientDataGetter) GetLastKCBatchID(ctx context.Context) (ui
 	builder.Function(getLastBatchId)
 
 	return dataGetter.executeQueryUint64FromBuilder(ctx, builder)
+}
+
+// ConvertEthToKdaAmount converts an amount from Ethereum decimals to KDA decimals
+func (dataGetter *klvClientDataGetter) ConvertEthToKdaAmount(ctx context.Context, token []byte, amount *big.Int) (*big.Int, error) {
+	builder := dataGetter.createSafeDefaultVmQueryBuilder()
+	builder.Function(convertEthToKdaAmountFuncName).ArgBytes(token).ArgBigInt(amount)
+
+	return dataGetter.executeQueryBigIntFromBuilder(ctx, builder)
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/clients/klever/klvClientDataGetter_test.go
+++ b/clients/klever/klvClientDataGetter_test.go
@@ -76,6 +76,7 @@ func createMockBatch() *bridgeCore.TransferBatch {
 				DestinationTokenBytes: []byte("converted_token1"),
 				DisplayableToken:      "token1",
 				Amount:                big.NewInt(2),
+				ConvertedAmount:       big.NewInt(200),
 				Data:                  []byte{0x00},
 				DisplayableData:       "00",
 			},
@@ -89,6 +90,7 @@ func createMockBatch() *bridgeCore.TransferBatch {
 				DestinationTokenBytes: []byte("converted_token2"),
 				DisplayableToken:      "token2",
 				Amount:                big.NewInt(4),
+				ConvertedAmount:       big.NewInt(400),
 				Data:                  []byte{0x00},
 				DisplayableData:       "00",
 			},
@@ -599,6 +601,7 @@ func TestKlvClientDataGetter_WasProposedTransfer(t *testing.T) {
 					hex.EncodeToString([]byte("to1")),
 					hex.EncodeToString([]byte("converted_token1")),
 					hex.EncodeToString(big.NewInt(2).Bytes()),
+					hex.EncodeToString(big.NewInt(200).Bytes()),
 					hex.EncodeToString(big.NewInt(1).Bytes()),
 					hex.EncodeToString([]byte{bridgeCore.MissingDataProtocolMarker}),
 
@@ -606,6 +609,7 @@ func TestKlvClientDataGetter_WasProposedTransfer(t *testing.T) {
 					hex.EncodeToString([]byte("to2")),
 					hex.EncodeToString([]byte("converted_token2")),
 					hex.EncodeToString(big.NewInt(4).Bytes()),
+					hex.EncodeToString(big.NewInt(400).Bytes()),
 					hex.EncodeToString(big.NewInt(3).Bytes()),
 					hex.EncodeToString([]byte{bridgeCore.MissingDataProtocolMarker}),
 				}
@@ -651,6 +655,7 @@ func TestKlvClientDataGetter_WasProposedTransfer(t *testing.T) {
 					hex.EncodeToString([]byte("to1")),
 					hex.EncodeToString([]byte("converted_token1")),
 					hex.EncodeToString(big.NewInt(2).Bytes()),
+					hex.EncodeToString(big.NewInt(200).Bytes()),
 					hex.EncodeToString(big.NewInt(1).Bytes()),
 					hex.EncodeToString(bridgeTests.CallDataMock),
 
@@ -658,6 +663,7 @@ func TestKlvClientDataGetter_WasProposedTransfer(t *testing.T) {
 					hex.EncodeToString([]byte("to2")),
 					hex.EncodeToString([]byte("converted_token2")),
 					hex.EncodeToString(big.NewInt(4).Bytes()),
+					hex.EncodeToString(big.NewInt(400).Bytes()),
 					hex.EncodeToString(big.NewInt(3).Bytes()),
 					hex.EncodeToString([]byte{bridgeCore.MissingDataProtocolMarker}),
 				}
@@ -773,6 +779,7 @@ func TestKlvClientDataGetter_GetActionIDForProposeTransfer(t *testing.T) {
 					hex.EncodeToString([]byte("to1")),
 					hex.EncodeToString([]byte("converted_token1")),
 					hex.EncodeToString(big.NewInt(2).Bytes()),
+					hex.EncodeToString(big.NewInt(200).Bytes()),
 					hex.EncodeToString(big.NewInt(1).Bytes()),
 					hex.EncodeToString([]byte{bridgeCore.MissingDataProtocolMarker}),
 
@@ -780,6 +787,7 @@ func TestKlvClientDataGetter_GetActionIDForProposeTransfer(t *testing.T) {
 					hex.EncodeToString([]byte("to2")),
 					hex.EncodeToString([]byte("converted_token2")),
 					hex.EncodeToString(big.NewInt(4).Bytes()),
+					hex.EncodeToString(big.NewInt(400).Bytes()),
 					hex.EncodeToString(big.NewInt(3).Bytes()),
 					hex.EncodeToString([]byte{bridgeCore.MissingDataProtocolMarker}),
 				}
@@ -824,6 +832,7 @@ func TestKlvClientDataGetter_GetActionIDForProposeTransfer(t *testing.T) {
 					hex.EncodeToString([]byte("to1")),
 					hex.EncodeToString([]byte("converted_token1")),
 					hex.EncodeToString(big.NewInt(2).Bytes()),
+					hex.EncodeToString(big.NewInt(200).Bytes()),
 					hex.EncodeToString(big.NewInt(1).Bytes()),
 					hex.EncodeToString(bridgeTests.CallDataMock),
 
@@ -831,6 +840,7 @@ func TestKlvClientDataGetter_GetActionIDForProposeTransfer(t *testing.T) {
 					hex.EncodeToString([]byte("to2")),
 					hex.EncodeToString([]byte("converted_token2")),
 					hex.EncodeToString(big.NewInt(4).Bytes()),
+					hex.EncodeToString(big.NewInt(400).Bytes()),
 					hex.EncodeToString(big.NewInt(3).Bytes()),
 					hex.EncodeToString([]byte{bridgeCore.MissingDataProtocolMarker}),
 				}

--- a/clients/klever/proxy/baseProxy.go
+++ b/clients/klever/proxy/baseProxy.go
@@ -117,7 +117,7 @@ func (proxy *baseProxy) cacheConfigs(ctx context.Context) (*models.NetworkConfig
 func (proxy *baseProxy) getNetworkConfigFromSource(ctx context.Context) (*models.NetworkConfig, error) {
 	buff, code, err := proxy.GetHTTP(ctx, proxy.endpointProvider.GetNetworkConfig())
 	if err != nil || code != http.StatusOK {
-		return nil, createHTTPStatusError(code, err)
+		return nil, createHTTPStatusErrorWithBody(code, err, buff)
 	}
 
 	response := &models.NetworkConfigResponse{}
@@ -138,7 +138,7 @@ func (proxy *baseProxy) GetNetworkStatus(ctx context.Context) (*models.NodeOverv
 	endpoint := proxy.endpointProvider.GetNodeStatus()
 	buff, code, err := proxy.GetHTTP(ctx, endpoint)
 	if err != nil || code != http.StatusOK {
-		return nil, createHTTPStatusError(code, err)
+		return nil, createHTTPStatusErrorWithBody(code, err, buff)
 	}
 
 	response := &models.NodeOverviewApiResponse{}

--- a/clients/klever/proxy/proxy.go
+++ b/clients/klever/proxy/proxy.go
@@ -124,7 +124,7 @@ func (ep *proxy) ExecuteVMQuery(ctx context.Context, vmRequest *models.VmValueRe
 
 	buff, code, err := ep.PostHTTP(ctx, ep.endpointProvider.GetVmQuery(), jsonVMRequest)
 	if err != nil || code != http.StatusOK {
-		return nil, createHTTPStatusError(code, err)
+		return nil, createHTTPStatusErrorWithBody(code, err, buff)
 	}
 
 	endpointProviderType := ep.endpointProvider.GetRestAPIEntityType()
@@ -193,7 +193,7 @@ func (ep *proxy) getAccountNode(ctx context.Context, address address.Address) (*
 
 	buff, code, err := ep.GetHTTP(ctx, endpoint)
 	if err != nil || code != http.StatusOK {
-		return nil, createHTTPStatusError(code, err)
+		return nil, createHTTPStatusErrorWithBody(code, err, buff)
 	}
 
 	response := &models.AccountNodeResponse{}
@@ -214,7 +214,7 @@ func (ep *proxy) getAccountProxy(ctx context.Context, address address.Address) (
 
 	buff, code, err := ep.GetHTTP(ctx, endpoint)
 	if err != nil || code != http.StatusOK {
-		return nil, createHTTPStatusError(code, err)
+		return nil, createHTTPStatusErrorWithBody(code, err, buff)
 	}
 
 	response := &models.AccountApiResponse{}
@@ -247,7 +247,7 @@ func (ep *proxy) SendTransaction(ctx context.Context, tx *transaction.Transactio
 
 	buff, code, err := ep.PostHTTP(ctx, ep.endpointProvider.GetSendTransaction(), jsonTx)
 	if err != nil || code != http.StatusOK {
-		return "", createHTTPStatusError(code, err)
+		return "", createHTTPStatusErrorWithBody(code, err, buff)
 	}
 
 	response := &models.SendTransactionResponse{}
@@ -275,7 +275,7 @@ func (ep *proxy) SendTransactions(ctx context.Context, txs []*transaction.Transa
 
 	buff, code, err := ep.PostHTTP(ctx, ep.endpointProvider.GetSendMultipleTransactions(), jsonTx)
 	if err != nil || code != http.StatusOK {
-		return nil, createHTTPStatusError(code, err)
+		return nil, createHTTPStatusErrorWithBody(code, err, buff)
 	}
 
 	response := &models.SendBulkTransactionsResponse{}
@@ -295,7 +295,7 @@ func (ep *proxy) GetTransactionStatus(ctx context.Context, hash string) (string,
 	endpoint := ep.endpointProvider.GetTransactionStatus(hash)
 	buff, code, err := ep.GetHTTP(ctx, endpoint)
 	if err != nil || code != http.StatusOK {
-		return "", createHTTPStatusError(code, err)
+		return "", createHTTPStatusErrorWithBody(code, err, buff)
 	}
 
 	response := &models.TransactionStatus{}
@@ -328,7 +328,7 @@ func (ep *proxy) getTransactionInfo(ctx context.Context, hash string, withResult
 
 	buff, code, err := ep.GetHTTP(ctx, endpoint)
 	if err != nil || code != http.StatusOK {
-		return nil, createHTTPStatusError(code, err)
+		return nil, createHTTPStatusErrorWithBody(code, err, buff)
 	}
 
 	response := &models.GetTransactionResponse{}
@@ -351,7 +351,7 @@ func (ep *proxy) EstimateTransactionFees(ctx context.Context, tx *transaction.Tr
 	}
 	buff, code, err := ep.PostHTTP(ctx, ep.endpointProvider.GetEstimateTransactionFees(), jsonTx)
 	if err != nil || code != http.StatusOK {
-		return nil, createHTTPStatusError(code, err)
+		return nil, createHTTPStatusErrorWithBody(code, err, buff)
 	}
 
 	response := &models.EstimateTransactionFeesResponse{}
@@ -382,7 +382,7 @@ func (ep *proxy) GetKDATokenData(
 	endpoint := ep.endpointProvider.GetKDATokenData(address.Bech32(), tokenIdentifier)
 	buff, code, err := ep.GetHTTP(ctx, endpoint)
 	if err != nil || code != http.StatusOK {
-		return nil, createHTTPStatusError(code, err)
+		return nil, createHTTPStatusErrorWithBody(code, err, buff)
 	}
 
 	response := &models.KDAFungibleResponse{}

--- a/core/batch.go
+++ b/core/batch.go
@@ -75,6 +75,7 @@ type DepositTransfer struct {
 	DestinationTokenBytes []byte   `json:"-"`
 	DisplayableToken      string   `json:"token"`
 	Amount                *big.Int `json:"amount"`
+	ConvertedAmount       *big.Int `json:"convertedAmount"`
 	Data                  []byte   `json:"-"`
 	DisplayableData       string   `json:"data"`
 }
@@ -97,6 +98,7 @@ func (dt *DepositTransfer) Clone() *DepositTransfer {
 		DestinationTokenBytes: make([]byte, len(dt.DestinationTokenBytes)),
 		DisplayableToken:      dt.DisplayableToken,
 		Amount:                big.NewInt(0),
+		ConvertedAmount:       big.NewInt(0),
 		Data:                  make([]byte, len(dt.Data)),
 		DisplayableData:       dt.DisplayableData,
 	}
@@ -108,6 +110,9 @@ func (dt *DepositTransfer) Clone() *DepositTransfer {
 	copy(cloned.Data, dt.Data)
 	if dt.Amount != nil {
 		cloned.Amount.Set(dt.Amount)
+	}
+	if dt.ConvertedAmount != nil {
+		cloned.ConvertedAmount.Set(dt.ConvertedAmount)
 	}
 
 	return cloned

--- a/core/batch_test.go
+++ b/core/batch_test.go
@@ -19,6 +19,7 @@ func TestDepositTransfer_Clone(t *testing.T) {
 		SourceTokenBytes:      []byte("source token"),
 		DisplayableToken:      "token",
 		Amount:                big.NewInt(7463),
+		ConvertedAmount:       big.NewInt(746300),
 		DestinationTokenBytes: []byte("destination token"),
 		Data:                  []byte("tx data"),
 	}
@@ -62,6 +63,7 @@ func TestTransferBatch_Clone(t *testing.T) {
 				SourceTokenBytes:      []byte("source token1"),
 				DisplayableToken:      "token1",
 				Amount:                big.NewInt(3344),
+				ConvertedAmount:       big.NewInt(334400),
 				DestinationTokenBytes: []byte("destination token1"),
 				Data:                  []byte("tx data"),
 			},
@@ -74,6 +76,7 @@ func TestTransferBatch_Clone(t *testing.T) {
 				SourceTokenBytes:      []byte("source token2"),
 				DisplayableToken:      "token2",
 				Amount:                big.NewInt(5566),
+				ConvertedAmount:       big.NewInt(556600),
 				DestinationTokenBytes: []byte("destination token2"),
 				Data:                  []byte("tx data"),
 			},

--- a/integrationTests/mock/KcMock.go
+++ b/integrationTests/mock/KcMock.go
@@ -161,6 +161,16 @@ func (mock *KleverBlockchainMock) AddTokensPair(erc20 common.Address, ticker str
 	mock.addTokensPair(erc20, ticker, isNativeToken, isMintBurnToken, totalBalance, mintBalances, burnBalances)
 }
 
+// SetDecimalConversion sets the decimal conversion configuration for a token
+// The conversion is calculated as: convertedAmount = (amount * multiplier) / divisor
+// For example, ETH 18 decimals to KDA 6 decimals: multiplier=1, divisor=10^12
+func (mock *KleverBlockchainMock) SetDecimalConversion(ticker string, multiplier, divisor *big.Int) {
+	mock.mutState.Lock()
+	defer mock.mutState.Unlock()
+
+	mock.setDecimalConversion(ticker, multiplier, divisor)
+}
+
 // SetLastExecutedEthBatchID -
 func (mock *KleverBlockchainMock) SetLastExecutedEthBatchID(lastExecutedEthBatchId uint64) {
 	mock.mutState.Lock()

--- a/integrationTests/relayers/kcToEth_test.go
+++ b/integrationTests/relayers/kcToEth_test.go
@@ -248,12 +248,14 @@ func createTransactions(n int) ([]mock.KleverBlockchainDeposit, []common.Address
 
 func createTransaction(index int) (mock.KleverBlockchainDeposit, common.Address) {
 	tokenAddress := testsCommon.CreateRandomEthereumAddress()
+	amount := big.NewInt(int64(index*1000) + 500) // 0 as amount is not relevant
 
 	return mock.KleverBlockchainDeposit{
-		From:   testsCommon.CreateRandomKCAddress(),
-		To:     testsCommon.CreateRandomEthereumAddress(),
-		Ticker: fmt.Sprintf("tck-00000%d", index+1),
-		Amount: big.NewInt(int64(index*1000) + 500), // 0 as amount is not relevant
+		From:            testsCommon.CreateRandomKCAddress(),
+		To:              testsCommon.CreateRandomEthereumAddress(),
+		Ticker:          fmt.Sprintf("tck-00000%d", index+1),
+		Amount:          amount,
+		ConvertedAmount: amount, // default to same as Amount for now
 	}, tokenAddress
 }
 

--- a/integrationTests/relayers/kcToEth_test.go
+++ b/integrationTests/relayers/kcToEth_test.go
@@ -283,3 +283,193 @@ func checkTestStatus(
 		assert.Equal(t, deposits[i].Amount, transfer.Amounts[i])
 	}
 }
+
+// TestRelayersShouldExecuteTransfersFromKCToEthWithDecimalConversion tests the KC→ETH flow
+// when tokens have different decimal configurations. In this direction:
+// - Amount field contains the ETH-side amount (up to 18 decimals) - used for Ethereum execution
+// - ConvertedAmount field contains the KDA-side amount (max 8 decimals) - original amount, used for refunds
+func TestRelayersShouldExecuteTransfersFromKCToEthWithDecimalConversion(t *testing.T) {
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+
+	t.Run("8 to 18 decimals conversion", func(t *testing.T) {
+		// KDA 8 decimals → ETH 18 decimals (scale up by 10^10)
+		// Example: 1.5 tokens = 150,000,000 (KDA 8 decimals) → 1,500,000,000,000,000,000 wei (ETH 18 decimals)
+		testRelayersShouldExecuteTransfersFromKCToEthWithDecimalConversion(t, kcToEthDecimalConversionTestArgs{
+			kdaDecimals:    8,
+			ethDecimals:    18,
+			kdaAmount:      big.NewInt(150_000_000),                             // 1.5 in KDA 8 decimals
+			expectedEthAmt: big.NewInt(0).Mul(big.NewInt(15), big.NewInt(1e17)), // 1.5 ETH in wei
+		})
+	})
+	t.Run("6 to 18 decimals conversion", func(t *testing.T) {
+		// KDA 6 decimals → ETH 18 decimals (scale up by 10^12)
+		// Example: 2.5 tokens = 2,500,000 (KDA 6 decimals) → 2,500,000,000,000,000,000 (ETH 18 decimals)
+		testRelayersShouldExecuteTransfersFromKCToEthWithDecimalConversion(t, kcToEthDecimalConversionTestArgs{
+			kdaDecimals:    6,
+			ethDecimals:    18,
+			kdaAmount:      big.NewInt(2_500_000),                               // 2.5 in KDA 6 decimals
+			expectedEthAmt: big.NewInt(0).Mul(big.NewInt(25), big.NewInt(1e17)), // 2.5 ETH in wei
+		})
+	})
+	t.Run("same decimals no conversion", func(t *testing.T) {
+		// 8 decimals → 8 decimals (no conversion needed)
+		// Example: WKLV already has 8 decimals on both sides
+		testRelayersShouldExecuteTransfersFromKCToEthWithDecimalConversion(t, kcToEthDecimalConversionTestArgs{
+			kdaDecimals:    8,
+			ethDecimals:    8,
+			kdaAmount:      big.NewInt(100_000_000), // 1.0 token in 8 decimals
+			expectedEthAmt: big.NewInt(100_000_000), // same amount
+		})
+	})
+	t.Run("6 to 6 decimals no conversion USDC style", func(t *testing.T) {
+		// USDC: 6 decimals on both chains
+		testRelayersShouldExecuteTransfersFromKCToEthWithDecimalConversion(t, kcToEthDecimalConversionTestArgs{
+			kdaDecimals:    6,
+			ethDecimals:    6,
+			kdaAmount:      big.NewInt(1_000_000), // 1.0 USDC
+			expectedEthAmt: big.NewInt(1_000_000), // same amount
+		})
+	})
+}
+
+type kcToEthDecimalConversionTestArgs struct {
+	kdaDecimals    uint8
+	ethDecimals    uint8
+	kdaAmount      *big.Int
+	expectedEthAmt *big.Int
+}
+
+func testRelayersShouldExecuteTransfersFromKCToEthWithDecimalConversion(t *testing.T, args kcToEthDecimalConversionTestArgs) {
+	safeContractEthAddress := testsCommon.CreateRandomEthereumAddress()
+
+	tokenErc20 := testsCommon.CreateRandomEthereumAddress()
+	ticker := "tck-dec001"
+
+	from := testsCommon.CreateRandomKCAddress()
+	to := testsCommon.CreateRandomEthereumAddress()
+
+	// In KC→ETH flow:
+	// - Amount is the ETH-side amount (scaled up if needed)
+	// - ConvertedAmount is the original KDA-side amount
+	deposit := mock.KleverBlockchainDeposit{
+		From:            from,
+		To:              to,
+		Ticker:          ticker,
+		Amount:          args.expectedEthAmt, // ETH-side amount (already converted by KdaSafe.createTransaction)
+		ConvertedAmount: args.kdaAmount,      // Original KDA amount (for refunds)
+	}
+
+	deposits := []mock.KleverBlockchainDeposit{deposit}
+	tokens := []common.Address{tokenErc20}
+	availableBalances := []*big.Int{args.expectedEthAmt}
+
+	erc20ContractsHolder := createMockErc20ContractsHolder(tokens, safeContractEthAddress, availableBalances)
+
+	numRelayers := 3
+	ethereumChainMock := mock.NewEthereumChainMock()
+	ethereumChainMock.SetQuorum(numRelayers)
+	expectedStatuses := []byte{bridgeCore.Executed}
+	ethereumChainMock.GetStatusesAfterExecutionHandler = func() ([]byte, bool) {
+		if callIsFromBalanceValidator() {
+			return expectedStatuses, false
+		}
+		return expectedStatuses, true
+	}
+	ethereumChainMock.BalanceAtCalled = func(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
+		return relayerEthBalance, nil
+	}
+
+	// Configure as native token on Klever (mint/burn on Ethereum)
+	// For mint/burn tokens, both balances start at 0
+	ethereumChainMock.UpdateNativeTokens(tokenErc20, false)
+	ethereumChainMock.UpdateMintBurnTokens(tokenErc20, true)
+	ethereumChainMock.UpdateMintBalances(tokenErc20, zero)
+	ethereumChainMock.UpdateBurnBalances(tokenErc20, zero)
+
+	kcChainMock := mock.NewKleverBlockchainMock()
+	// For mint/burn tokens native on Klever: totalBalance=0, mintBalances=0, burnBalances=kdaAmount (KC-side)
+	// The last parameter is burnBalances which should be in KDA decimals
+	kcChainMock.AddTokensPair(tokenErc20, ticker, true, true, zero, zero, args.kdaAmount)
+
+	// Set up decimal conversion so balance validator can convert ETH amounts to KDA amounts
+	// For KC→ETH: ETH decimals = kdaAmount * multiplier / divisor when converting from ETH to KDA
+	// The conversion mock does: convertedAmount = (amount * multiplier) / divisor
+	// To convert from ETH to KDA: we need divisor to scale down (if ETH > KDA decimals)
+	var multiplier, divisor *big.Int
+	if args.ethDecimals > args.kdaDecimals {
+		multiplier = big.NewInt(1)
+		decimalDiff := args.ethDecimals - args.kdaDecimals
+		divisor = new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(decimalDiff)), nil)
+	} else if args.ethDecimals < args.kdaDecimals {
+		decimalDiff := args.kdaDecimals - args.ethDecimals
+		multiplier = new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(decimalDiff)), nil)
+		divisor = big.NewInt(1)
+	} else {
+		multiplier = big.NewInt(1)
+		divisor = big.NewInt(1)
+	}
+	kcChainMock.SetDecimalConversion(ticker, multiplier, divisor)
+
+	pendingBatch := mock.KleverBlockchainPendingBatch{
+		Nonce:                    big.NewInt(1),
+		KleverBlockchainDeposits: deposits,
+	}
+	kcChainMock.SetPendingBatch(&pendingBatch)
+	kcChainMock.SetQuorum(numRelayers)
+
+	relayers := make([]bridgeComponents, 0, numRelayers)
+	defer closeRelayers(relayers)
+
+	messengers := integrationTests.CreateLinkedMessengers(numRelayers)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*300)
+	defer cancel()
+	kcChainMock.ProcessFinishedHandler = func() {
+		log.Info("kcChainMock.ProcessFinishedHandler called - decimal conversion test")
+		asyncCancelCall(cancel, time.Second*5)
+	}
+
+	for i := 0; i < numRelayers; i++ {
+		argsBridgeComponents := createMockBridgeComponentsArgs(i, messengers[i], kcChainMock, ethereumChainMock)
+		argsBridgeComponents.Configs.GeneralConfig.Eth.SafeContractAddress = safeContractEthAddress.Hex()
+		argsBridgeComponents.Erc20ContractsHolder = erc20ContractsHolder
+
+		relayer, err := factory.NewEthKleverBridgeComponents(argsBridgeComponents)
+		require.NoError(t, err)
+
+		kcChainMock.AddRelayer(relayer.KleverRelayerAddress())
+		ethereumChainMock.AddRelayer(relayer.EthereumRelayerAddress())
+
+		relayers = append(relayers, relayer)
+		go func(r bridgeComponents) {
+			if err := r.Start(); err != nil {
+				integrationTests.Log.LogIfError(err)
+				assert.NoError(t, err)
+			}
+		}(relayer)
+	}
+
+	<-ctx.Done()
+	time.Sleep(time.Second * 5)
+
+	// Verify the transfer was processed
+	transactions := kcChainMock.GetAllSentTransactions(context.Background())
+	assert.Equal(t, 5, len(transactions))
+	assert.Nil(t, kcChainMock.ProposedTransfer())
+	assert.NotNil(t, kcChainMock.PerformedActionID())
+
+	transfer := ethereumChainMock.GetLastProposedTransfer()
+	require.NotNil(t, transfer)
+	require.Equal(t, 1, len(transfer.Amounts))
+
+	// Verify the transfer to Ethereum uses the ETH-side amount (scaled up)
+	assert.Equal(t, to, transfer.Recipients[0])
+	assert.Equal(t, tokenErc20, transfer.Tokens[0])
+
+	// This is the key validation: Ethereum receives the ETH-decimals amount
+	assert.Equal(t, args.expectedEthAmt, transfer.Amounts[0],
+		"Ethereum should receive the ETH-side amount (KDA %d → ETH %d decimals)",
+		args.kdaDecimals, args.ethDecimals)
+}

--- a/testsCommon/bridge/kcClientStub.go
+++ b/testsCommon/bridge/kcClientStub.go
@@ -25,6 +25,7 @@ type KCClientStub struct {
 	GetLastExecutedEthBatchIDCalled                func(ctx context.Context) (uint64, error)
 	GetLastExecutedEthTxIDCalled                   func(ctx context.Context) (uint64, error)
 	GetCurrentNonceCalled                          func(ctx context.Context) (uint64, error)
+	ConvertEthToKdaAmountCalled                    func(ctx context.Context, token []byte, amount *big.Int) (*big.Int, error)
 	ProposeSetStatusCalled                         func(ctx context.Context, batch *bridgeCore.TransferBatch) (string, error)
 	ResolveNewDepositsCalled                       func(ctx context.Context, batch *bridgeCore.TransferBatch) error
 	ProposeTransferCalled                          func(ctx context.Context, batch *bridgeCore.TransferBatch) (string, error)
@@ -157,6 +158,15 @@ func (stub *KCClientStub) GetCurrentNonce(ctx context.Context) (uint64, error) {
 	}
 
 	return 0, nil
+}
+
+// ConvertEthToKdaAmount -
+func (stub *KCClientStub) ConvertEthToKdaAmount(ctx context.Context, token []byte, amount *big.Int) (*big.Int, error) {
+	if stub.ConvertEthToKdaAmountCalled != nil {
+		return stub.ConvertEthToKdaAmountCalled(ctx, token, amount)
+	}
+
+	return amount, nil
 }
 
 // ProposeSetStatus -


### PR DESCRIPTION
This pull request introduces a consistent approach for handling deposit amounts by converting Ethereum decimal values to KDA decimals across the bridge and validator logic. It ensures that all comparisons and storage of amounts use the correct decimal format, which is critical for maintaining accuracy between chains. The changes also propagate this logic to the test suite and client interfaces.

**Core logic and conversion improvements:**

* Added the `ConvertEthToKdaAmount` method to the `KCClient` interface and implemented it in both the bridge and validator clients, allowing conversion of deposit amounts from Ethereum to KDA decimals. [[1]](diffhunk://#diff-dd8be85b6dd9ca1fa5c745e2cf22e1c2ea73fcd173debf552726f3ff10f7c5e2R29) [[2]](diffhunk://#diff-7721759d87ac52977ad5c52abafc9aee6cbf9c7fafe1e8f3628fdcce1345189cR23) [[3]](diffhunk://#diff-30d0e97ac911109e041700958c0455efbda9e76a90e91c07d974fa706d0fb020R478-R482) [[4]](diffhunk://#diff-64f5deb108f3a295bc85e65e7674d83746b9cb5ae8afe1e35659876a88c499a8R521-R528)
* Updated the bridge executor (`bridgeExecutor.go`) to convert all deposit amounts to KDA decimals before storing batches, ensuring downstream logic always works with KDA-formatted amounts.

**Balance validation and batch handling:**

* Modified the balance validator to compare balances using KDA decimals by converting Ethereum amounts before comparison, and updated the logging to reflect both original and converted balances.
* Changed the logic for summing transfer amounts in pending batches to use the new `ConvertedAmount` field, ensuring all calculations are in KDA decimals. [[1]](diffhunk://#diff-d985b1e1cab898690f28047e47e19509be4103497c61ec29ba354231e449c96cR281-R292) [[2]](diffhunk://#diff-d985b1e1cab898690f28047e47e19509be4103497c61ec29ba354231e449c96cL296-R319) [[3]](diffhunk://#diff-d985b1e1cab898690f28047e47e19509be4103497c61ec29ba354231e449c96cR228)

**Batch and deposit struct updates:**

* Updated batch creation and parsing logic to handle an additional field (`ConvertedAmount`) for each deposit, and ensured all functions and tests that construct or verify batches/deposits include this field. (F20f01aaL20R20, [[1]](diffhunk://#diff-30d0e97ac911109e041700958c0455efbda9e76a90e91c07d974fa706d0fb020L269-R283) [[2]](diffhunk://#diff-30d0e97ac911109e041700958c0455efbda9e76a90e91c07d974fa706d0fb020R293) [[3]](diffhunk://#diff-30d0e97ac911109e041700958c0455efbda9e76a90e91c07d974fa706d0fb020R365) [[4]](diffhunk://#diff-64f5deb108f3a295bc85e65e7674d83746b9cb5ae8afe1e35659876a88c499a8R491)

**Test updates:**

* Adjusted test helpers and assertions to account for the new `ConvertedAmount` field and the updated number of arguments in batch-related methods, ensuring tests reflect the new data structure. [[1]](diffhunk://#diff-03941cd81be69d1795fb9f01f759e55abf5ddd5d2e5d50c6b13b4043a6791cfbL88-R89) [[2]](diffhunk://#diff-03941cd81be69d1795fb9f01f759e55abf5ddd5d2e5d50c6b13b4043a6791cfbL274-R275) [[3]](diffhunk://#diff-03941cd81be69d1795fb9f01f759e55abf5ddd5d2e5d50c6b13b4043a6791cfbL305-R306) [[4]](diffhunk://#diff-03941cd81be69d1795fb9f01f759e55abf5ddd5d2e5d50c6b13b4043a6791cfbR362) [[5]](diffhunk://#diff-03941cd81be69d1795fb9f01f759e55abf5ddd5d2e5d50c6b13b4043a6791cfbR374) [[6]](diffhunk://#diff-03941cd81be69d1795fb9f01f759e55abf5ddd5d2e5d50c6b13b4043a6791cfbL431-R434) [[7]](diffhunk://#diff-03941cd81be69d1795fb9f01f759e55abf5ddd5d2e5d50c6b13b4043a6791cfbL462-R465) [[8]](diffhunk://#diff-03941cd81be69d1795fb9f01f759e55abf5ddd5d2e5d50c6b13b4043a6791cfbR521) [[9]](diffhunk://#diff-03941cd81be69d1795fb9f01f759e55abf5ddd5d2e5d50c6b13b4043a6791cfbR533) [[10]](diffhunk://#diff-03941cd81be69d1795fb9f01f759e55abf5ddd5d2e5d50c6b13b4043a6791cfbR784) [[11]](diffhunk://#diff-445f44d6c54c8bda8c66c7f4f9c593ccc7f549182c85f4e0338cfa4efab7b19aR79) [[12]](diffhunk://#diff-445f44d6c54c8bda8c66c7f4f9c593ccc7f549182c85f4e0338cfa4efab7b19aR93) [[13]](diffhunk://#diff-445f44d6c54c8bda8c66c7f4f9c593ccc7f549182c85f4e0338cfa4efab7b19aR604-R612) [[14]](diffhunk://#diff-445f44d6c54c8bda8c66c7f4f9c593ccc7f549182c85f4e0338cfa4efab7b19aR658-R666)

These changes together ensure that all cross-chain operations and validations use a consistent, accurate representation of token amounts, reducing the risk of mismatches and errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic decimal conversion of Ethereum deposit amounts to KDA decimals; converted values are now carried with deposits and exposed via conversion API.

* **Bug Fixes**
  * Balance validation now compares amounts using aligned decimals.
  * API error reporting includes HTTP response bodies for clearer diagnostics.
  * New explicit error when a deposit is missing its converted amount.

* **Tests**
  * Expanded unit and integration tests for decimal-conversion flows, mismatch cases, and error propagation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->