### PR TITLE
[KLC-2116] Add monitoring metrics to bridge relayer API

### DIFF
--- a/bridges/ethKC/bridgeExecutor.go
+++ b/bridges/ethKC/bridgeExecutor.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/klever-io/klv-bridge-eth-go/clients"
 	"github.com/klever-io/klv-bridge-eth-go/clients/ethereum/contract"
-	"github.com/klever-io/klv-bridge-eth-go/core"
 	bridgeCore "github.com/klever-io/klv-bridge-eth-go/core"
 	"github.com/klever-io/klv-bridge-eth-go/core/batchProcessor"
 	"github.com/multiversx/mx-chain-core-go/core/check"
@@ -30,7 +29,7 @@ type ArgsBridgeExecutor struct {
 	KCClient                   KCClient
 	EthereumClient             EthereumClient
 	TimeForWaitOnEthereum      time.Duration
-	StatusHandler              core.StatusHandler
+	StatusHandler              bridgeCore.StatusHandler
 	SignaturesHolder           SignaturesHolder
 	BalanceValidator           BalanceValidator
 	MaxQuorumRetriesOnEthereum uint64
@@ -44,7 +43,7 @@ type bridgeExecutor struct {
 	kcClient                   KCClient
 	ethereumClient             EthereumClient
 	timeForWaitOnEthereum      time.Duration
-	statusHandler              core.StatusHandler
+	statusHandler              bridgeCore.StatusHandler
 	sigsHolder                 SignaturesHolder
 	balanceValidator           BalanceValidator
 	maxQuorumRetriesOnEthereum uint64
@@ -142,16 +141,16 @@ func (executor *bridgeExecutor) setExecutionMessageInStatusHandler(level logger.
 		msg += fmt.Sprintf(" %s = %s", convertObjectToString(extras[i]), convertObjectToString(extras[i+1]))
 	}
 
-	executor.statusHandler.SetStringMetric(core.MetricLastError, msg)
+	executor.statusHandler.SetStringMetric(bridgeCore.MetricLastError, msg)
 }
 
 // MyTurnAsLeader returns true if the current relayer node is the leader
 func (executor *bridgeExecutor) MyTurnAsLeader() bool {
 	isLeader := executor.topologyProvider.MyTurnAsLeader()
 	if isLeader {
-		executor.statusHandler.SetStringMetric(core.MetricIsLeader, "true")
+		executor.statusHandler.SetStringMetric(bridgeCore.MetricIsLeader, "true")
 	} else {
-		executor.statusHandler.SetStringMetric(core.MetricIsLeader, "false")
+		executor.statusHandler.SetStringMetric(bridgeCore.MetricIsLeader, "false")
 	}
 	return isLeader
 }
@@ -160,9 +159,9 @@ func (executor *bridgeExecutor) MyTurnAsLeader() bool {
 func (executor *bridgeExecutor) GetBatchFromKC(ctx context.Context) (*bridgeCore.TransferBatch, error) {
 	batch, err := executor.kcClient.GetPendingBatch(ctx)
 	if err == nil {
-		executor.statusHandler.SetIntMetric(core.MetricNumBatches, int(batch.ID)-1)
+		executor.statusHandler.SetIntMetric(bridgeCore.MetricNumBatches, int(batch.ID)-1)
 		if len(batch.Deposits) > 0 {
-			executor.statusHandler.SetIntMetric(core.MetricCurrentDepositNonce, int(batch.Deposits[0].Nonce))
+			executor.statusHandler.SetIntMetric(bridgeCore.MetricCurrentDepositNonce, int(batch.Deposits[0].Nonce))
 		}
 	}
 	return batch, err
@@ -175,7 +174,7 @@ func (executor *bridgeExecutor) StoreBatchFromKC(batch *bridgeCore.TransferBatch
 	}
 
 	executor.batch = batch
-	executor.statusHandler.SetIntMetric(core.MetricCurrentBatchID, int(batch.ID))
+	executor.statusHandler.SetIntMetric(bridgeCore.MetricCurrentBatchID, int(batch.ID))
 	return nil
 }
 
@@ -188,7 +187,7 @@ func (executor *bridgeExecutor) GetStoredBatch() *bridgeCore.TransferBatch {
 func (executor *bridgeExecutor) GetLastExecutedEthBatchIDFromKC(ctx context.Context) (uint64, error) {
 	batchID, err := executor.kcClient.GetLastExecutedEthBatchID(ctx)
 	if err == nil {
-		executor.statusHandler.SetIntMetric(core.MetricNumBatches, int(batchID))
+		executor.statusHandler.SetIntMetric(bridgeCore.MetricNumBatches, int(batchID))
 	}
 	return batchID, err
 }
@@ -473,7 +472,7 @@ func (executor *bridgeExecutor) GetAndStoreBatchFromEthereum(ctx context.Context
 	}
 
 	executor.batch = batch
-	executor.statusHandler.SetIntMetric(core.MetricCurrentBatchID, int(batch.ID))
+	executor.statusHandler.SetIntMetric(bridgeCore.MetricCurrentBatchID, int(batch.ID))
 
 	return nil
 }

--- a/bridges/ethKC/bridgeExecutor.go
+++ b/bridges/ethKC/bridgeExecutor.go
@@ -147,7 +147,13 @@ func (executor *bridgeExecutor) setExecutionMessageInStatusHandler(level logger.
 
 // MyTurnAsLeader returns true if the current relayer node is the leader
 func (executor *bridgeExecutor) MyTurnAsLeader() bool {
-	return executor.topologyProvider.MyTurnAsLeader()
+	isLeader := executor.topologyProvider.MyTurnAsLeader()
+	if isLeader {
+		executor.statusHandler.SetStringMetric(core.MetricIsLeader, "true")
+	} else {
+		executor.statusHandler.SetStringMetric(core.MetricIsLeader, "false")
+	}
+	return isLeader
 }
 
 // GetBatchFromKC fetches the pending batch from KC
@@ -155,6 +161,9 @@ func (executor *bridgeExecutor) GetBatchFromKC(ctx context.Context) (*bridgeCore
 	batch, err := executor.kcClient.GetPendingBatch(ctx)
 	if err == nil {
 		executor.statusHandler.SetIntMetric(core.MetricNumBatches, int(batch.ID)-1)
+		if len(batch.Deposits) > 0 {
+			executor.statusHandler.SetIntMetric(core.MetricCurrentDepositNonce, int(batch.Deposits[0].Nonce))
+		}
 	}
 	return batch, err
 }
@@ -166,6 +175,7 @@ func (executor *bridgeExecutor) StoreBatchFromKC(batch *bridgeCore.TransferBatch
 	}
 
 	executor.batch = batch
+	executor.statusHandler.SetIntMetric(core.MetricCurrentBatchID, int(batch.ID))
 	return nil
 }
 
@@ -463,6 +473,7 @@ func (executor *bridgeExecutor) GetAndStoreBatchFromEthereum(ctx context.Context
 	}
 
 	executor.batch = batch
+	executor.statusHandler.SetIntMetric(core.MetricCurrentBatchID, int(batch.ID))
 
 	return nil
 }

--- a/bridges/ethKC/bridgeExecutor.go
+++ b/bridges/ethKC/bridgeExecutor.go
@@ -473,6 +473,10 @@ func (executor *bridgeExecutor) GetAndStoreBatchFromEthereum(ctx context.Context
 
 	executor.batch = batch
 	executor.statusHandler.SetIntMetric(bridgeCore.MetricCurrentBatchID, safeUint64ToInt(batch.ID))
+	if len(batch.Deposits) > 0 {
+		lastDeposit := batch.Deposits[len(batch.Deposits)-1]
+		executor.statusHandler.SetIntMetric(bridgeCore.MetricCurrentDepositNonce, safeUint64ToInt(lastDeposit.Nonce))
+	}
 
 	return nil
 }

--- a/bridges/ethKC/bridgeExecutor.go
+++ b/bridges/ethKC/bridgeExecutor.go
@@ -5,7 +5,9 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"math"
 	"math/big"
+	"strconv"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -147,11 +149,7 @@ func (executor *bridgeExecutor) setExecutionMessageInStatusHandler(level logger.
 // MyTurnAsLeader returns true if the current relayer node is the leader
 func (executor *bridgeExecutor) MyTurnAsLeader() bool {
 	isLeader := executor.topologyProvider.MyTurnAsLeader()
-	if isLeader {
-		executor.statusHandler.SetStringMetric(bridgeCore.MetricIsLeader, "true")
-	} else {
-		executor.statusHandler.SetStringMetric(bridgeCore.MetricIsLeader, "false")
-	}
+	executor.statusHandler.SetStringMetric(bridgeCore.MetricIsLeader, strconv.FormatBool(isLeader))
 	return isLeader
 }
 
@@ -159,9 +157,10 @@ func (executor *bridgeExecutor) MyTurnAsLeader() bool {
 func (executor *bridgeExecutor) GetBatchFromKC(ctx context.Context) (*bridgeCore.TransferBatch, error) {
 	batch, err := executor.kcClient.GetPendingBatch(ctx)
 	if err == nil {
-		executor.statusHandler.SetIntMetric(bridgeCore.MetricNumBatches, int(batch.ID)-1)
+		executor.statusHandler.SetIntMetric(bridgeCore.MetricNumBatches, safeUint64ToInt(batch.ID)-1)
 		if len(batch.Deposits) > 0 {
-			executor.statusHandler.SetIntMetric(bridgeCore.MetricCurrentDepositNonce, int(batch.Deposits[0].Nonce))
+			lastDeposit := batch.Deposits[len(batch.Deposits)-1]
+			executor.statusHandler.SetIntMetric(bridgeCore.MetricCurrentDepositNonce, safeUint64ToInt(lastDeposit.Nonce))
 		}
 	}
 	return batch, err
@@ -174,7 +173,7 @@ func (executor *bridgeExecutor) StoreBatchFromKC(batch *bridgeCore.TransferBatch
 	}
 
 	executor.batch = batch
-	executor.statusHandler.SetIntMetric(bridgeCore.MetricCurrentBatchID, int(batch.ID))
+	executor.statusHandler.SetIntMetric(bridgeCore.MetricCurrentBatchID, safeUint64ToInt(batch.ID))
 	return nil
 }
 
@@ -187,7 +186,7 @@ func (executor *bridgeExecutor) GetStoredBatch() *bridgeCore.TransferBatch {
 func (executor *bridgeExecutor) GetLastExecutedEthBatchIDFromKC(ctx context.Context) (uint64, error) {
 	batchID, err := executor.kcClient.GetLastExecutedEthBatchID(ctx)
 	if err == nil {
-		executor.statusHandler.SetIntMetric(bridgeCore.MetricNumBatches, int(batchID))
+		executor.statusHandler.SetIntMetric(bridgeCore.MetricNumBatches, safeUint64ToInt(batchID))
 	}
 	return batchID, err
 }
@@ -472,7 +471,7 @@ func (executor *bridgeExecutor) GetAndStoreBatchFromEthereum(ctx context.Context
 	}
 
 	executor.batch = batch
-	executor.statusHandler.SetIntMetric(bridgeCore.MetricCurrentBatchID, int(batch.ID))
+	executor.statusHandler.SetIntMetric(bridgeCore.MetricCurrentBatchID, safeUint64ToInt(batch.ID))
 
 	return nil
 }
@@ -682,6 +681,13 @@ func (executor *bridgeExecutor) CheckKCClientAvailability(ctx context.Context) e
 // CheckEthereumClientAvailability trigger a self availability check for the Ethereum client
 func (executor *bridgeExecutor) CheckEthereumClientAvailability(ctx context.Context) error {
 	return executor.ethereumClient.CheckClientAvailability(ctx)
+}
+
+func safeUint64ToInt(v uint64) int {
+	if v > uint64(math.MaxInt) {
+		return math.MaxInt
+	}
+	return int(v)
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/bridges/ethKC/bridgeExecutor.go
+++ b/bridges/ethKC/bridgeExecutor.go
@@ -157,7 +157,8 @@ func (executor *bridgeExecutor) MyTurnAsLeader() bool {
 func (executor *bridgeExecutor) GetBatchFromKC(ctx context.Context) (*bridgeCore.TransferBatch, error) {
 	batch, err := executor.kcClient.GetPendingBatch(ctx)
 	if err == nil {
-		executor.statusHandler.SetIntMetric(bridgeCore.MetricNumBatches, safeUint64ToInt(batch.ID)-1)
+		n := max(safeUint64ToInt(batch.ID)-1, 0)
+		executor.statusHandler.SetIntMetric(bridgeCore.MetricNumBatches, n)
 		if len(batch.Deposits) > 0 {
 			lastDeposit := batch.Deposits[len(batch.Deposits)-1]
 			executor.statusHandler.SetIntMetric(bridgeCore.MetricCurrentDepositNonce, safeUint64ToInt(lastDeposit.Nonce))

--- a/bridges/ethKC/bridgeExecutor_test.go
+++ b/bridges/ethKC/bridgeExecutor_test.go
@@ -401,7 +401,8 @@ func TestEthToKCBridgeExecutor_GetAndStoreBatchFromEthereum(t *testing.T) {
 		expectedBatch := &bridgeCore.TransferBatch{
 			ID: providedNonce,
 			Deposits: []*bridgeCore.DepositTransfer{
-				{},
+				{Nonce: 100},
+				{Nonce: 101},
 			},
 		}
 		args.EthereumClient = &bridgeTests.EthereumClientStub{
@@ -420,6 +421,7 @@ func TestEthToKCBridgeExecutor_GetAndStoreBatchFromEthereum(t *testing.T) {
 		assert.True(t, expectedBatch == executor.GetStoredBatch()) // pointer testing
 		assert.True(t, expectedBatch == executor.batch)
 		assert.Equal(t, int(providedNonce), statusHandler.GetIntMetric(bridgeCore.MetricCurrentBatchID))
+		assert.Equal(t, 101, statusHandler.GetIntMetric(bridgeCore.MetricCurrentDepositNonce))
 	})
 	t.Run("should add deposits metadata for sc calls", func(t *testing.T) {
 		t.Parallel()

--- a/bridges/ethKC/bridgeExecutor_test.go
+++ b/bridges/ethKC/bridgeExecutor_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var expectedErr = errors.New("expected error")
+var errExpected = errors.New("expected error")
 var providedBatch = &bridgeCore.TransferBatch{}
 var expectedMaxRetries = uint64(3)
 
@@ -265,7 +265,7 @@ func TestEthToKCBridgeExecutor_GetAndStoreActionIDForProposeTransferOnKC(t *test
 		args.KCClient = &bridgeTests.KCClientStub{
 			GetActionIDForProposeTransferCalled: func(ctx context.Context, batch *bridgeCore.TransferBatch) (uint64, error) {
 				assert.True(t, providedBatch == batch)
-				return 0, expectedErr
+				return 0, errExpected
 			},
 		}
 		executor, _ := NewBridgeExecutor(args)
@@ -273,7 +273,7 @@ func TestEthToKCBridgeExecutor_GetAndStoreActionIDForProposeTransferOnKC(t *test
 
 		actionID, err := executor.GetAndStoreActionIDForProposeTransferOnKC(context.Background())
 		assert.Zero(t, actionID)
-		assert.Equal(t, expectedErr, err)
+		assert.Equal(t, errExpected, err)
 	})
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
@@ -311,13 +311,13 @@ func TestEthToKCBridgeExecutor_GetAndStoreBatchFromEthereum(t *testing.T) {
 		args.EthereumClient = &bridgeTests.EthereumClientStub{
 			GetBatchCalled: func(ctx context.Context, nonce uint64) (*bridgeCore.TransferBatch, bool, error) {
 				assert.Equal(t, providedNonce, nonce)
-				return nil, false, expectedErr
+				return nil, false, errExpected
 			},
 		}
 		executor, _ := NewBridgeExecutor(args)
 		err := executor.GetAndStoreBatchFromEthereum(context.Background(), providedNonce)
 
-		assert.Equal(t, expectedErr, err)
+		assert.Equal(t, errExpected, err)
 	})
 	t.Run("batch nonce mismatch should error", func(t *testing.T) {
 		t.Parallel()
@@ -603,14 +603,14 @@ func TestEthToKCBridgeExecutor_VerifyLastDepositNonceExecutedOnEthereumBatch(t *
 		args := createMockExecutorArgs()
 		args.KCClient = &bridgeTests.KCClientStub{
 			GetLastExecutedEthTxIDCalled: func(ctx context.Context) (uint64, error) {
-				return 0, expectedErr
+				return 0, errExpected
 			},
 		}
 		executor, _ := NewBridgeExecutor(args)
 		executor.batch = &bridgeCore.TransferBatch{}
 
 		err := executor.VerifyLastDepositNonceExecutedOnEthereumBatch(context.Background())
-		assert.Equal(t, expectedErr, err)
+		assert.Equal(t, errExpected, err)
 	})
 
 	args := createMockExecutorArgs()
@@ -759,14 +759,14 @@ func TestEthToKCBridgeExecutor_ProposeTransferOnKC(t *testing.T) {
 			ProposeTransferCalled: func(ctx context.Context, batch *bridgeCore.TransferBatch) (string, error) {
 				assert.True(t, providedBatch == batch)
 
-				return "", expectedErr
+				return "", errExpected
 			},
 		}
 		executor, _ := NewBridgeExecutor(args)
 		executor.batch = providedBatch
 
 		err := executor.ProposeTransferOnKC(context.Background())
-		assert.Equal(t, expectedErr, err)
+		assert.Equal(t, errExpected, err)
 	})
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
@@ -823,7 +823,7 @@ func TestEthToKCBridgeExecutor_SignActionOnKC(t *testing.T) {
 		args.KCClient = &bridgeTests.KCClientStub{
 			SignCalled: func(ctx context.Context, actionID uint64) (string, error) {
 				assert.Equal(t, providedActionID, actionID)
-				return "", expectedErr
+				return "", errExpected
 			},
 		}
 
@@ -831,7 +831,7 @@ func TestEthToKCBridgeExecutor_SignActionOnKC(t *testing.T) {
 		executor.actionID = providedActionID
 
 		err := executor.SignActionOnKC(context.Background())
-		assert.Equal(t, expectedErr, err)
+		assert.Equal(t, errExpected, err)
 	})
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
@@ -921,7 +921,7 @@ func TestEthToKCBridgeExecutor_PerformActionOnKC(t *testing.T) {
 			PerformActionCalled: func(ctx context.Context, actionID uint64, batch *bridgeCore.TransferBatch) (string, error) {
 				assert.Equal(t, providedActionID, actionID)
 				assert.True(t, providedBatch == batch)
-				return "", expectedErr
+				return "", errExpected
 			},
 		}
 		executor, _ := NewBridgeExecutor(args)
@@ -929,7 +929,7 @@ func TestEthToKCBridgeExecutor_PerformActionOnKC(t *testing.T) {
 		executor.actionID = providedActionID
 
 		err := executor.PerformActionOnKC(context.Background())
-		assert.Equal(t, expectedErr, err)
+		assert.Equal(t, errExpected, err)
 	})
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
@@ -996,13 +996,13 @@ func TestKCToEthBridgeExecutor_GetAndStoreBatchFromKC(t *testing.T) {
 		args := createMockExecutorArgs()
 		args.KCClient = &bridgeTests.KCClientStub{
 			GetPendingBatchCalled: func(ctx context.Context) (*bridgeCore.TransferBatch, error) {
-				return nil, expectedErr
+				return nil, errExpected
 			},
 		}
 
 		executor, _ := NewBridgeExecutor(args)
 		_, err := executor.GetBatchFromKC(context.Background())
-		assert.Equal(t, expectedErr, err)
+		assert.Equal(t, errExpected, err)
 
 		batch := executor.GetStoredBatch()
 		assert.Nil(t, batch)
@@ -1070,14 +1070,14 @@ func TestKCToEthBridgeExecutor_GetAndStoreActionIDForProposeSetStatusFromKC(t *t
 		args := createMockExecutorArgs()
 		args.KCClient = &bridgeTests.KCClientStub{
 			GetActionIDForSetStatusOnPendingTransferCalled: func(ctx context.Context, batch *bridgeCore.TransferBatch) (uint64, error) {
-				return uint64(0), expectedErr
+				return uint64(0), errExpected
 			},
 		}
 
 		executor, _ := NewBridgeExecutor(args)
 		executor.batch = providedBatch
 		_, err := executor.GetAndStoreActionIDForProposeSetStatusFromKC(context.Background())
-		assert.Equal(t, expectedErr, err)
+		assert.Equal(t, errExpected, err)
 	})
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
@@ -1123,14 +1123,14 @@ func TestKCToEthBridgeExecutor_WasSetStatusProposedOnKC(t *testing.T) {
 		args := createMockExecutorArgs()
 		args.KCClient = &bridgeTests.KCClientStub{
 			WasProposedSetStatusCalled: func(ctx context.Context, batch *bridgeCore.TransferBatch) (bool, error) {
-				return false, expectedErr
+				return false, errExpected
 			},
 		}
 
 		executor, _ := NewBridgeExecutor(args)
 		executor.batch = providedBatch
 		_, err := executor.WasSetStatusProposedOnKC(context.Background())
-		assert.Equal(t, expectedErr, err)
+		assert.Equal(t, errExpected, err)
 	})
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
@@ -1172,14 +1172,14 @@ func TestEthToKCBridgeExecutor_ProposeSetStatusOnKC(t *testing.T) {
 		args := createMockExecutorArgs()
 		args.KCClient = &bridgeTests.KCClientStub{
 			ProposeSetStatusCalled: func(ctx context.Context, batch *bridgeCore.TransferBatch) (string, error) {
-				return "", expectedErr
+				return "", errExpected
 			},
 		}
 
 		executor, _ := NewBridgeExecutor(args)
 		executor.batch = providedBatch
 		err := executor.ProposeSetStatusOnKC(context.Background())
-		assert.Equal(t, expectedErr, err)
+		assert.Equal(t, errExpected, err)
 	})
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
@@ -1242,14 +1242,14 @@ func TestKCToEthBridgeExecutor_WasTransferPerformedOnEthereum(t *testing.T) {
 		args := createMockExecutorArgs()
 		args.EthereumClient = &bridgeTests.EthereumClientStub{
 			WasExecutedCalled: func(ctx context.Context, batchID uint64) (bool, error) {
-				return false, expectedErr
+				return false, errExpected
 			},
 		}
 
 		executor, _ := NewBridgeExecutor(args)
 		executor.batch = providedBatch
 		_, err := executor.WasTransferPerformedOnEthereum(context.Background())
-		assert.Equal(t, expectedErr, err)
+		assert.Equal(t, errExpected, err)
 	})
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
@@ -1293,14 +1293,14 @@ func TestKCToEthBridgeExecutor_SignTransferOnEthereum(t *testing.T) {
 		args := createMockExecutorArgs()
 		args.EthereumClient = &bridgeTests.EthereumClientStub{
 			GenerateMessageHashCalled: func(batch *batchProcessor.ArgListsBatch, batchID uint64) (common.Hash, error) {
-				return common.Hash{}, expectedErr
+				return common.Hash{}, errExpected
 			},
 		}
 
 		executor, _ := NewBridgeExecutor(args)
 		executor.batch = providedBatch
 		err := executor.SignTransferOnEthereum()
-		assert.Equal(t, expectedErr, err)
+		assert.Equal(t, errExpected, err)
 	})
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
@@ -1345,14 +1345,14 @@ func TestKCToEthBridgeExecutor_PerformTransferOnEthereum(t *testing.T) {
 		args := createMockExecutorArgs()
 		args.EthereumClient = &bridgeTests.EthereumClientStub{
 			GetQuorumSizeCalled: func(ctx context.Context) (*big.Int, error) {
-				return big.NewInt(0), expectedErr
+				return big.NewInt(0), errExpected
 			},
 		}
 
 		executor, _ := NewBridgeExecutor(args)
 		executor.batch = providedBatch
 		err := executor.PerformTransferOnEthereum(context.Background())
-		assert.Equal(t, expectedErr, err)
+		assert.Equal(t, errExpected, err)
 	})
 	t.Run("ExecuteTransfer fails", func(t *testing.T) {
 		t.Parallel()
@@ -1363,14 +1363,14 @@ func TestKCToEthBridgeExecutor_PerformTransferOnEthereum(t *testing.T) {
 				return big.NewInt(0), nil
 			},
 			ExecuteTransferCalled: func(ctx context.Context, msgHash common.Hash, batch *batchProcessor.ArgListsBatch, batchId uint64, quorum int) (string, error) {
-				return "", expectedErr
+				return "", errExpected
 			},
 		}
 
 		executor, _ := NewBridgeExecutor(args)
 		executor.batch = providedBatch
 		err := executor.PerformTransferOnEthereum(context.Background())
-		assert.Equal(t, expectedErr, err)
+		assert.Equal(t, errExpected, err)
 	})
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
@@ -1421,14 +1421,14 @@ func TestKCToEthBridgeExecutor_IsQuorumReachedOnEthereum(t *testing.T) {
 		args := createMockExecutorArgs()
 		args.EthereumClient = &bridgeTests.EthereumClientStub{
 			IsQuorumReachedCalled: func(ctx context.Context, msgHash common.Hash) (bool, error) {
-				return false, expectedErr
+				return false, errExpected
 			},
 		}
 
 		executor, _ := NewBridgeExecutor(args)
 
 		_, err := executor.ProcessQuorumReachedOnEthereum(context.Background())
-		assert.Equal(t, expectedErr, err)
+		assert.Equal(t, errExpected, err)
 	})
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
@@ -1571,14 +1571,14 @@ func TestGetBatchStatusesFromEthereum(t *testing.T) {
 		args := createMockExecutorArgs()
 		args.EthereumClient = &bridgeTests.EthereumClientStub{
 			GetTransactionsStatusesCalled: func(ctx context.Context, batchId uint64) ([]byte, error) {
-				return nil, expectedErr
+				return nil, errExpected
 			},
 		}
 
 		executor, _ := NewBridgeExecutor(args)
 		executor.batch = providedBatch
 		_, err := executor.GetBatchStatusesFromEthereum(context.Background())
-		assert.Equal(t, expectedErr, err)
+		assert.Equal(t, errExpected, err)
 	})
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
@@ -1645,7 +1645,7 @@ func TestWaitAndReturnFinalBatchStatuses(t *testing.T) {
 		args.EthereumClient = &bridgeTests.EthereumClientStub{
 			GetTransactionsStatusesCalled: func(ctx context.Context, batchId uint64) ([]byte, error) {
 				counter++
-				return nil, expectedErr
+				return nil, errExpected
 			},
 		}
 		executor, _ := NewBridgeExecutor(args)
@@ -1672,7 +1672,7 @@ func TestWaitAndReturnFinalBatchStatuses(t *testing.T) {
 				if counter >= 5 {
 					return providedStatuses, nil
 				}
-				return nil, expectedErr
+				return nil, errExpected
 			},
 		}
 		executor, _ := NewBridgeExecutor(args)

--- a/bridges/ethKC/bridgeExecutor_test.go
+++ b/bridges/ethKC/bridgeExecutor_test.go
@@ -1027,6 +1027,8 @@ func TestKCToEthBridgeExecutor_GetAndStoreBatchFromKC(t *testing.T) {
 		batchWithDeposits := &bridgeCore.TransferBatch{
 			ID: 5,
 			Deposits: []*bridgeCore.DepositTransfer{
+				{Nonce: 40},
+				{Nonce: 41},
 				{Nonce: 42},
 			},
 		}

--- a/bridges/ethKC/bridgeExecutor_test.go
+++ b/bridges/ethKC/bridgeExecutor_test.go
@@ -208,18 +208,41 @@ func testPrintInfo(t *testing.T, logLevel logger.LogLevel, shouldOutputToStatusH
 func TestEthToKCBridgeExecutor_MyTurnAsLeader(t *testing.T) {
 	t.Parallel()
 
-	args := createMockExecutorArgs()
-	wasCalled := false
-	args.TopologyProvider = &bridgeTests.TopologyProviderStub{
-		MyTurnAsLeaderCalled: func() bool {
-			wasCalled = true
-			return true
-		},
-	}
+	t.Run("is leader", func(t *testing.T) {
+		t.Parallel()
 
-	executor, _ := NewBridgeExecutor(args)
-	assert.True(t, executor.MyTurnAsLeader())
-	assert.True(t, wasCalled)
+		args := createMockExecutorArgs()
+		statusHandler := testsCommon.NewStatusHandlerMock("test")
+		args.StatusHandler = statusHandler
+		wasCalled := false
+		args.TopologyProvider = &bridgeTests.TopologyProviderStub{
+			MyTurnAsLeaderCalled: func() bool {
+				wasCalled = true
+				return true
+			},
+		}
+
+		executor, _ := NewBridgeExecutor(args)
+		assert.True(t, executor.MyTurnAsLeader())
+		assert.True(t, wasCalled)
+		assert.Equal(t, "true", statusHandler.GetStringMetric(bridgeCore.MetricIsLeader))
+	})
+	t.Run("is not leader", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockExecutorArgs()
+		statusHandler := testsCommon.NewStatusHandlerMock("test")
+		args.StatusHandler = statusHandler
+		args.TopologyProvider = &bridgeTests.TopologyProviderStub{
+			MyTurnAsLeaderCalled: func() bool {
+				return false
+			},
+		}
+
+		executor, _ := NewBridgeExecutor(args)
+		assert.False(t, executor.MyTurnAsLeader())
+		assert.Equal(t, "false", statusHandler.GetStringMetric(bridgeCore.MetricIsLeader))
+	})
 }
 
 func TestEthToKCBridgeExecutor_GetAndStoreActionIDForProposeTransferOnKC(t *testing.T) {
@@ -372,6 +395,8 @@ func TestEthToKCBridgeExecutor_GetAndStoreBatchFromEthereum(t *testing.T) {
 		t.Parallel()
 
 		args := createMockExecutorArgs()
+		statusHandler := testsCommon.NewStatusHandlerMock("test")
+		args.StatusHandler = statusHandler
 		providedNonce := uint64(8346)
 		expectedBatch := &bridgeCore.TransferBatch{
 			ID: providedNonce,
@@ -394,6 +419,7 @@ func TestEthToKCBridgeExecutor_GetAndStoreBatchFromEthereum(t *testing.T) {
 		assert.Nil(t, err)
 		assert.True(t, expectedBatch == executor.GetStoredBatch()) // pointer testing
 		assert.True(t, expectedBatch == executor.batch)
+		assert.Equal(t, int(providedNonce), statusHandler.GetIntMetric(bridgeCore.MetricCurrentBatchID))
 	})
 	t.Run("should add deposits metadata for sc calls", func(t *testing.T) {
 		t.Parallel()
@@ -996,22 +1022,32 @@ func TestKCToEthBridgeExecutor_GetAndStoreBatchFromKC(t *testing.T) {
 
 		wasCalled := false
 		args := createMockExecutorArgs()
+		statusHandler := testsCommon.NewStatusHandlerMock("test")
+		args.StatusHandler = statusHandler
+		batchWithDeposits := &bridgeCore.TransferBatch{
+			ID: 5,
+			Deposits: []*bridgeCore.DepositTransfer{
+				{Nonce: 42},
+			},
+		}
 		args.KCClient = &bridgeTests.KCClientStub{
 			GetPendingBatchCalled: func(ctx context.Context) (*bridgeCore.TransferBatch, error) {
 				wasCalled = true
-				return providedBatch, nil
+				return batchWithDeposits, nil
 			},
 		}
 
 		executor, _ := NewBridgeExecutor(args)
 		batch, err := executor.GetBatchFromKC(context.Background())
 		assert.True(t, wasCalled)
-		assert.Equal(t, providedBatch, batch)
+		assert.Equal(t, batchWithDeposits, batch)
 		assert.Nil(t, err)
+		assert.Equal(t, 42, statusHandler.GetIntMetric(bridgeCore.MetricCurrentDepositNonce))
 
 		err = executor.StoreBatchFromKC(batch)
-		assert.Equal(t, providedBatch, executor.batch)
+		assert.Equal(t, batchWithDeposits, executor.batch)
 		assert.Nil(t, err)
+		assert.Equal(t, 5, statusHandler.GetIntMetric(bridgeCore.MetricCurrentBatchID))
 	})
 }
 
@@ -1172,6 +1208,8 @@ func TestKCToEthBridgeExecutor_MyTurnAsLeader(t *testing.T) {
 	t.Parallel()
 
 	args := createMockExecutorArgs()
+	statusHandler := testsCommon.NewStatusHandlerMock("test")
+	args.StatusHandler = statusHandler
 	wasCalled := false
 	args.TopologyProvider = &bridgeTests.TopologyProviderStub{
 		MyTurnAsLeaderCalled: func() bool {
@@ -1183,6 +1221,7 @@ func TestKCToEthBridgeExecutor_MyTurnAsLeader(t *testing.T) {
 	executor, _ := NewBridgeExecutor(args)
 	assert.True(t, executor.MyTurnAsLeader())
 	assert.True(t, wasCalled)
+	assert.Equal(t, "true", statusHandler.GetStringMetric(bridgeCore.MetricIsLeader))
 }
 
 func TestKCToEthBridgeExecutor_WasTransferPerformedOnEthereum(t *testing.T) {

--- a/bridges/ethKC/steps/ethToKC/step01GetPending_test.go
+++ b/bridges/ethKC/steps/ethToKC/step01GetPending_test.go
@@ -7,14 +7,13 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/klever-io/klv-bridge-eth-go/core"
 	bridgeCore "github.com/klever-io/klv-bridge-eth-go/core"
 	"github.com/klever-io/klv-bridge-eth-go/core/batchProcessor"
 	bridgeTests "github.com/klever-io/klv-bridge-eth-go/testsCommon/bridge"
 	"github.com/stretchr/testify/assert"
 )
 
-var expectedError = errors.New("expected error")
+var errExpected = errors.New("expected error")
 var testBatch = &bridgeCore.TransferBatch{
 	ID: 112233,
 	Deposits: []*bridgeCore.DepositTransfer{
@@ -37,7 +36,7 @@ func TestExecuteGetPending(t *testing.T) {
 		t.Parallel()
 		bridgeStub := createStubExecutor()
 		bridgeStub.GetLastExecutedEthBatchIDFromKCCalled = func(ctx context.Context) (uint64, error) {
-			return 1122, expectedError
+			return 1122, errExpected
 		}
 
 		step := getPendingStep{
@@ -55,7 +54,7 @@ func TestExecuteGetPending(t *testing.T) {
 			return 1122, nil
 		}
 		bridgeStub.GetAndStoreBatchFromEthereumCalled = func(ctx context.Context, nonce uint64) error {
-			return expectedError
+			return errExpected
 		}
 
 		step := getPendingStep{
@@ -99,7 +98,7 @@ func TestExecuteGetPending(t *testing.T) {
 			return testBatch
 		}
 		bridgeStub.VerifyLastDepositNonceExecutedOnEthereumBatchCalled = func(ctx context.Context) error {
-			return expectedError
+			return errExpected
 		}
 
 		step := getPendingStep{
@@ -114,7 +113,7 @@ func TestExecuteGetPending(t *testing.T) {
 		t.Parallel()
 		bridgeStub := createStubExecutor()
 		bridgeStub.CheckAvailableTokensCalled = func(ctx context.Context, ethTokens []common.Address, kdaTokens [][]byte, amounts []*big.Int, direction batchProcessor.Direction) error {
-			return expectedError
+			return errExpected
 		}
 		bridgeStub.GetLastExecutedEthBatchIDFromKCCalled = func(ctx context.Context) (uint64, error) {
 			return 1122, nil
@@ -162,7 +161,7 @@ func TestExecuteGetPending(t *testing.T) {
 			bridge: bridgeStub,
 		}
 		// Test Identifier()
-		expectedStepIdentifier := core.StepIdentifier(GettingPendingBatchFromEthereum)
+		expectedStepIdentifier := bridgeCore.StepIdentifier(GettingPendingBatchFromEthereum)
 		assert.Equal(t, expectedStepIdentifier, step.Identifier())
 		// Test IsInterfaceNil()
 		assert.False(t, step.IsInterfaceNil())

--- a/bridges/ethKC/steps/ethToKC/step02ProposeTransfer_test.go
+++ b/bridges/ethKC/steps/ethToKC/step02ProposeTransfer_test.go
@@ -34,7 +34,7 @@ func TestExecuteProposeTransfer(t *testing.T) {
 			return testBatch
 		}
 		bridgeStub.WasTransferProposedOnKCCalled = func(ctx context.Context) (bool, error) {
-			return false, expectedError
+			return false, errExpected
 		}
 
 		step := proposeTransferStep{
@@ -81,7 +81,7 @@ func TestExecuteProposeTransfer(t *testing.T) {
 			return true
 		}
 		bridgeStub.ProposeTransferOnKCCalled = func(ctx context.Context) error {
-			return expectedError
+			return errExpected
 		}
 
 		step := proposeTransferStep{

--- a/bridges/ethKC/steps/ethToKC/step03SignProposedTransfer_test.go
+++ b/bridges/ethKC/steps/ethToKC/step03SignProposedTransfer_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	ethKC "github.com/klever-io/klv-bridge-eth-go/bridges/ethKC"
-	"github.com/klever-io/klv-bridge-eth-go/core"
 	bridgeCore "github.com/klever-io/klv-bridge-eth-go/core"
 	"github.com/stretchr/testify/assert"
 )
@@ -25,7 +24,7 @@ func TestExecuteSignProposedTransferStep(t *testing.T) {
 			bridge: bridgeStub,
 		}
 
-		expectedStepIdentifier := core.StepIdentifier(GettingPendingBatchFromEthereum)
+		expectedStepIdentifier := bridgeCore.StepIdentifier(GettingPendingBatchFromEthereum)
 		stepIdentifier := step.Execute(context.Background())
 		assert.Equal(t, expectedStepIdentifier, stepIdentifier)
 	})
@@ -37,14 +36,14 @@ func TestExecuteSignProposedTransferStep(t *testing.T) {
 			return testBatch
 		}
 		bridgeStub.WasActionSignedOnKCCalled = func(ctx context.Context) (bool, error) {
-			return false, expectedError
+			return false, errExpected
 		}
 
 		step := signProposedTransferStep{
 			bridge: bridgeStub,
 		}
 
-		expectedStepIdentifier := core.StepIdentifier(GettingPendingBatchFromEthereum)
+		expectedStepIdentifier := bridgeCore.StepIdentifier(GettingPendingBatchFromEthereum)
 		stepIdentifier := step.Execute(context.Background())
 		assert.Equal(t, expectedStepIdentifier, stepIdentifier)
 	})
@@ -59,14 +58,14 @@ func TestExecuteSignProposedTransferStep(t *testing.T) {
 			return false, nil
 		}
 		bridgeStub.SignActionOnKCCalled = func(ctx context.Context) error {
-			return expectedError
+			return errExpected
 		}
 
 		step := signProposedTransferStep{
 			bridge: bridgeStub,
 		}
 
-		expectedStepIdentifier := core.StepIdentifier(GettingPendingBatchFromEthereum)
+		expectedStepIdentifier := bridgeCore.StepIdentifier(GettingPendingBatchFromEthereum)
 		stepIdentifier := step.Execute(context.Background())
 		assert.Equal(t, expectedStepIdentifier, stepIdentifier)
 	})
@@ -89,7 +88,7 @@ func TestExecuteSignProposedTransferStep(t *testing.T) {
 			bridge: bridgeStub,
 		}
 
-		expectedStepIdentifier := core.StepIdentifier(GettingPendingBatchFromEthereum)
+		expectedStepIdentifier := bridgeCore.StepIdentifier(GettingPendingBatchFromEthereum)
 		stepIdentifier := step.Execute(context.Background())
 		assert.Equal(t, expectedStepIdentifier, stepIdentifier)
 	})
@@ -111,7 +110,7 @@ func TestExecuteSignProposedTransferStep(t *testing.T) {
 			bridge: bridgeStub,
 		}
 
-		expectedStepIdentifier := core.StepIdentifier(GettingPendingBatchFromEthereum)
+		expectedStepIdentifier := bridgeCore.StepIdentifier(GettingPendingBatchFromEthereum)
 		stepIdentifier := step.Execute(context.Background())
 		assert.Equal(t, expectedStepIdentifier, stepIdentifier)
 	})
@@ -123,7 +122,7 @@ func TestExecuteSignProposedTransferStep(t *testing.T) {
 			return testBatch
 		}
 		bridgeStub.WasActionSignedOnKCCalled = func(ctx context.Context) (bool, error) {
-			return false, expectedError
+			return false, errExpected
 		}
 		bridgeStub.GetAndStoreActionIDForProposeTransferOnKCCalled = func(ctx context.Context) (uint64, error) {
 			return ethKC.InvalidActionID, nil
@@ -133,7 +132,7 @@ func TestExecuteSignProposedTransferStep(t *testing.T) {
 			bridge: bridgeStub,
 		}
 
-		expectedStepIdentifier := core.StepIdentifier(GettingPendingBatchFromEthereum)
+		expectedStepIdentifier := bridgeCore.StepIdentifier(GettingPendingBatchFromEthereum)
 		stepIdentifier := step.Execute(context.Background())
 		assert.Equal(t, expectedStepIdentifier, stepIdentifier)
 	})
@@ -155,7 +154,7 @@ func TestExecuteSignProposedTransferStep(t *testing.T) {
 			bridge: bridgeStub,
 		}
 
-		expectedStepIdentifier := core.StepIdentifier(WaitingForQuorum)
+		expectedStepIdentifier := bridgeCore.StepIdentifier(WaitingForQuorum)
 		stepIdentifier := step.Execute(context.Background())
 		assert.Equal(t, expectedStepIdentifier, stepIdentifier)
 	})
@@ -180,7 +179,7 @@ func TestExecuteSignProposedTransferStep(t *testing.T) {
 			bridge: bridgeStub,
 		}
 		// Test Identifier()
-		expectedStepIdentifier := core.StepIdentifier(SigningProposedTransferOnKC)
+		expectedStepIdentifier := bridgeCore.StepIdentifier(SigningProposedTransferOnKC)
 		assert.Equal(t, expectedStepIdentifier, step.Identifier())
 		// Test IsInterfaceNil
 		assert.False(t, step.IsInterfaceNil())

--- a/bridges/ethKC/steps/ethToKC/step04WaitForQuorum_test.go
+++ b/bridges/ethKC/steps/ethToKC/step04WaitForQuorum_test.go
@@ -15,7 +15,7 @@ func TestExecuteWaitForQuorumStep(t *testing.T) {
 		t.Parallel()
 		bridgeStub := createStubExecutor()
 		bridgeStub.ProcessQuorumReachedOnKCCalled = func(ctx context.Context) (bool, error) {
-			return false, expectedError
+			return false, errExpected
 		}
 
 		step := waitForQuorumStep{

--- a/bridges/ethKC/steps/ethToKC/step05PerformActionID_test.go
+++ b/bridges/ethKC/steps/ethToKC/step05PerformActionID_test.go
@@ -15,7 +15,7 @@ func TestExecutePerformActionIDStep(t *testing.T) {
 		t.Parallel()
 		bridgeStub := createStubExecutor()
 		bridgeStub.WasActionPerformedOnKCCalled = func(ctx context.Context) (bool, error) {
-			return false, expectedError
+			return false, errExpected
 		}
 
 		step := performActionIDStep{
@@ -72,7 +72,7 @@ func TestExecutePerformActionIDStep(t *testing.T) {
 			return true
 		}
 		bridgeStub.PerformActionOnKCCalled = func(ctx context.Context) error {
-			return expectedError
+			return errExpected
 		}
 
 		step := performActionIDStep{

--- a/bridges/ethKC/steps/kcToEth/step01GetPending_test.go
+++ b/bridges/ethKC/steps/kcToEth/step01GetPending_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var expectedError = errors.New("expected error")
+var errExpected = errors.New("expected error")
 var testBatch = &bridgeCore.TransferBatch{
 	ID:       112233,
 	Deposits: nil,
@@ -27,7 +27,7 @@ func TestExecute_GetPending(t *testing.T) {
 		t.Parallel()
 		bridgeStub := createStubExecutorGetPending()
 		bridgeStub.GetBatchFromKCCalled = func(ctx context.Context) (*bridgeCore.TransferBatch, error) {
-			return nil, expectedError
+			return nil, errExpected
 		}
 
 		step := getPendingStep{
@@ -57,7 +57,7 @@ func TestExecute_GetPending(t *testing.T) {
 		t.Parallel()
 		bridgeStub := createStubExecutorGetPending()
 		bridgeStub.StoreBatchFromKCCalled = func(batch *bridgeCore.TransferBatch) error {
-			return expectedError
+			return errExpected
 		}
 
 		step := getPendingStep{
@@ -72,7 +72,7 @@ func TestExecute_GetPending(t *testing.T) {
 		t.Parallel()
 		bridgeStub := createStubExecutorGetPending()
 		bridgeStub.WasTransferPerformedOnEthereumCalled = func(ctx context.Context) (bool, error) {
-			return false, expectedError
+			return false, errExpected
 		}
 
 		step := getPendingStep{
@@ -90,7 +90,7 @@ func TestExecute_GetPending(t *testing.T) {
 			return false, nil
 		}
 		bridgeStub.CheckAvailableTokensCalled = func(ctx context.Context, ethTokens []common.Address, kdaTokens [][]byte, amounts []*big.Int, direction batchProcessor.Direction) error {
-			return expectedError
+			return errExpected
 		}
 
 		step := getPendingStep{

--- a/bridges/ethKC/steps/kcToEth/step02SignProposedTransfer_test.go
+++ b/bridges/ethKC/steps/kcToEth/step02SignProposedTransfer_test.go
@@ -33,7 +33,7 @@ func TestExecute_SignProposedTransfer(t *testing.T) {
 		t.Parallel()
 		bridgeStub := createStubExecutorSignProposedTransfer()
 		bridgeStub.SignTransferOnEthereumCalled = func() error {
-			return expectedError
+			return errExpected
 		}
 
 		step := signProposedTransferStep{

--- a/bridges/ethKC/steps/kcToEth/step03WaitForQuorumOnTransfer_test.go
+++ b/bridges/ethKC/steps/kcToEth/step03WaitForQuorumOnTransfer_test.go
@@ -16,7 +16,7 @@ func TestExecute_WaitForQuorumOnTransfer(t *testing.T) {
 		t.Parallel()
 		bridgeStub := createStubExecutorWaitForQuorumOnTransfer()
 		bridgeStub.ProcessQuorumReachedOnEthereumCalled = func(ctx context.Context) (bool, error) {
-			return false, expectedError
+			return false, errExpected
 		}
 
 		step := waitForQuorumOnTransferStep{

--- a/bridges/ethKC/steps/kcToEth/step04PerformTransfer_test.go
+++ b/bridges/ethKC/steps/kcToEth/step04PerformTransfer_test.go
@@ -16,7 +16,7 @@ func TestExecute_PerformTransfer(t *testing.T) {
 		t.Parallel()
 		bridgeStub := createStubExecutorPerformTransfer()
 		bridgeStub.WasTransferPerformedOnEthereumCalled = func(ctx context.Context) (bool, error) {
-			return false, expectedError
+			return false, errExpected
 		}
 
 		step := performTransferStep{
@@ -34,7 +34,7 @@ func TestExecute_PerformTransfer(t *testing.T) {
 			return true
 		}
 		bridgeStub.PerformTransferOnEthereumCalled = func(ctx context.Context) error {
-			return expectedError
+			return errExpected
 		}
 
 		step := performTransferStep{

--- a/bridges/ethKC/steps/kcToEth/step06ResolveSetStatus_test.go
+++ b/bridges/ethKC/steps/kcToEth/step06ResolveSetStatus_test.go
@@ -35,7 +35,7 @@ func TestExecute_ResolveSetStatus(t *testing.T) {
 		t.Parallel()
 		bridgeStub := createStubExecutorResolveSetStatus()
 		bridgeStub.GetBatchFromKCCalled = func(ctx context.Context) (*bridgeCore.TransferBatch, error) {
-			return nil, expectedError
+			return nil, errExpected
 		}
 		clearWasCalled := false
 		bridgeStub.ClearStoredP2PSignaturesForEthereumCalled = func() {

--- a/bridges/ethKC/steps/kcToEth/step07ProposeSetStatus_test.go
+++ b/bridges/ethKC/steps/kcToEth/step07ProposeSetStatus_test.go
@@ -45,7 +45,7 @@ func TestExecute_ProposeSetStatus(t *testing.T) {
 		t.Parallel()
 		bridgeStub := createStubExecutorProposeSetStatus()
 		bridgeStub.WasSetStatusProposedOnKCCalled = func(ctx context.Context) (bool, error) {
-			return false, expectedError
+			return false, errExpected
 		}
 
 		step := proposeSetStatusStep{
@@ -60,7 +60,7 @@ func TestExecute_ProposeSetStatus(t *testing.T) {
 		t.Parallel()
 		bridgeStub := createStubExecutorProposeSetStatus()
 		bridgeStub.ProposeSetStatusOnKCCalled = func(ctx context.Context) error {
-			return expectedError
+			return errExpected
 		}
 
 		step := proposeSetStatusStep{

--- a/bridges/ethKC/steps/kcToEth/step08SignProposedSetStatus_test.go
+++ b/bridges/ethKC/steps/kcToEth/step08SignProposedSetStatus_test.go
@@ -32,7 +32,7 @@ func TestExecute_SignProposedSetStatus(t *testing.T) {
 		t.Parallel()
 		bridgeStub := createStubExecutorSignProposedSetStatus()
 		bridgeStub.GetAndStoreActionIDForProposeSetStatusFromKCCalled = func(ctx context.Context) (uint64, error) {
-			return ethKC.InvalidActionID, expectedError
+			return ethKC.InvalidActionID, errExpected
 		}
 
 		step := signProposedSetStatusStep{
@@ -60,7 +60,7 @@ func TestExecute_SignProposedSetStatus(t *testing.T) {
 		t.Parallel()
 		bridgeStub := createStubExecutorSignProposedSetStatus()
 		bridgeStub.WasActionSignedOnKCCalled = func(ctx context.Context) (bool, error) {
-			return false, expectedError
+			return false, errExpected
 		}
 
 		step := signProposedSetStatusStep{
@@ -74,7 +74,7 @@ func TestExecute_SignProposedSetStatus(t *testing.T) {
 		t.Parallel()
 		bridgeStub := createStubExecutorSignProposedSetStatus()
 		bridgeStub.SignActionOnKCCalled = func(ctx context.Context) error {
-			return expectedError
+			return errExpected
 		}
 
 		step := signProposedSetStatusStep{

--- a/bridges/ethKC/steps/kcToEth/step09WaitForQuorumOnSetStatus_test.go
+++ b/bridges/ethKC/steps/kcToEth/step09WaitForQuorumOnSetStatus_test.go
@@ -16,7 +16,7 @@ func TestExecute_WaitForQuorumOnSetStatus(t *testing.T) {
 		t.Parallel()
 		bridgeStub := createStubExecutorWaitForQuorumOnSetStatus()
 		bridgeStub.ProcessQuorumReachedOnKCCalled = func(ctx context.Context) (bool, error) {
-			return false, expectedError
+			return false, errExpected
 		}
 
 		step := waitForQuorumOnSetStatusStep{

--- a/bridges/ethKC/steps/kcToEth/step10PerformSetStatus_test.go
+++ b/bridges/ethKC/steps/kcToEth/step10PerformSetStatus_test.go
@@ -15,7 +15,7 @@ func TestExecute_PerformSetStatus(t *testing.T) {
 		t.Parallel()
 		bridgeStub := createStubExecutorPerformSetStatus()
 		bridgeStub.WasActionPerformedOnKCCalled = func(ctx context.Context) (bool, error) {
-			return false, expectedError
+			return false, errExpected
 		}
 
 		step := performSetStatusStep{
@@ -33,7 +33,7 @@ func TestExecute_PerformSetStatus(t *testing.T) {
 			return true
 		}
 		bridgeStub.PerformActionOnKCCalled = func(ctx context.Context) error {
-			return expectedError
+			return errExpected
 		}
 
 		step := performSetStatusStep{

--- a/clients/ethereum/client.go
+++ b/clients/ethereum/client.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/klever-io/klv-bridge-eth-go/clients"
 	"github.com/klever-io/klv-bridge-eth-go/clients/ethereum/contract"
-	"github.com/klever-io/klv-bridge-eth-go/core"
 	bridgeCore "github.com/klever-io/klv-bridge-eth-go/core"
 	"github.com/klever-io/klv-bridge-eth-go/core/batchProcessor"
 	chainCore "github.com/multiversx/mx-chain-core-go/core"
@@ -30,7 +29,7 @@ type ArgsEthereumClient struct {
 	ClientWrapper                ClientWrapper
 	Erc20ContractsHandler        Erc20ContractsHolder
 	Log                          chainCore.Logger
-	AddressConverter             core.AddressConverter
+	AddressConverter             bridgeCore.AddressConverter
 	Broadcaster                  Broadcaster
 	CryptoHandler                CryptoHandler
 	TokensMapper                 TokensMapper
@@ -48,7 +47,7 @@ type client struct {
 	clientWrapper                ClientWrapper
 	erc20ContractsHandler        Erc20ContractsHolder
 	log                          chainCore.Logger
-	addressConverter             core.AddressConverter
+	addressConverter             bridgeCore.AddressConverter
 	broadcaster                  Broadcaster
 	cryptoHandler                CryptoHandler
 	tokensMapper                 TokensMapper
@@ -423,9 +422,9 @@ func (c *client) incrementRetriesAvailabilityCheck() {
 }
 
 func (c *client) setStatusForAvailabilityCheck(status bridgeCore.ClientStatus, message string, nonce uint64) {
-	c.clientWrapper.SetStringMetric(core.MetricKCClientStatus, status.String())
-	c.clientWrapper.SetStringMetric(core.MetricLastKCClientError, message)
-	c.clientWrapper.SetIntMetric(core.MetricLastBlockNonce, int(nonce))
+	c.clientWrapper.SetStringMetric(bridgeCore.MetricKCClientStatus, status.String())
+	c.clientWrapper.SetStringMetric(bridgeCore.MetricLastKCClientError, message)
+	c.clientWrapper.SetIntMetric(bridgeCore.MetricLastBlockNonce, int(nonce))
 }
 
 // CheckRequiredBalance will check if the safe has enough balance for the transfer

--- a/clients/klever/interactors/nonceHandlerV2/addressNonceHandler_test.go
+++ b/clients/klever/interactors/nonceHandlerV2/addressNonceHandler_test.go
@@ -18,7 +18,7 @@ import (
 
 var testAddressAsBech32String = "klv12e0kqcvqsrayj8j0c4dqjyvnv4ep253m5anx4rfj4jeq34lxsg8s84ec9j"
 var testAddress, _ = address.NewAddress(testAddressAsBech32String)
-var expectedErr = errors.New("expected error")
+var errExpected = errors.New("expected error")
 
 func TestAddressNonceHandler_NewAddressNonceHandlerWithPrivateAccess(t *testing.T) {
 	t.Parallel()
@@ -136,13 +136,13 @@ func TestAddressNonceHandler_getNonceUpdatingCurrent(t *testing.T) {
 
 		proxy := &testsCommon.ProxyStub{
 			GetAccountCalled: func(_ context.Context, address address.Address) (*models.Account, error) {
-				return nil, expectedErr
+				return nil, errExpected
 			},
 		}
 
 		anh, _ := NewAddressNonceHandlerWithPrivateAccess(proxy, testAddress)
 		nonce, err := anh.getNonceUpdatingCurrent(context.Background())
-		require.Equal(t, expectedErr, err)
+		require.Equal(t, errExpected, err)
 		require.Equal(t, uint64(0), nonce)
 	})
 	t.Run("gap nonce detected", func(t *testing.T) {
@@ -190,14 +190,14 @@ func TestAddressNonceHandler_getNonceUpdatingCurrent(t *testing.T) {
 
 		proxy := &testsCommon.ProxyStub{
 			GetAccountCalled: func(_ context.Context, address address.Address) (*models.Account, error) {
-				return nil, expectedErr
+				return nil, errExpected
 			},
 		}
 		anh, _ := NewAddressNonceHandlerWithPrivateAccess(proxy, testAddress)
 		tx := createDefaultTx(t)
 
 		err := anh.ApplyNonceAndGasPrice(context.Background(), tx)
-		require.Equal(t, expectedErr, err)
+		require.Equal(t, errExpected, err)
 	})
 	t.Run("getNonceUpdatingCurrent computed nonce concurrent usage should work", func(t *testing.T) {
 		t.Parallel()
@@ -241,13 +241,13 @@ func TestAddressNonceHandler_ReSendTransactionsIfRequired(t *testing.T) {
 
 		proxy := &testsCommon.ProxyStub{
 			GetAccountCalled: func(_ context.Context, address address.Address) (*models.Account, error) {
-				return nil, expectedErr
+				return nil, errExpected
 			},
 		}
 
 		anh, _ := NewAddressNonceHandlerWithPrivateAccess(proxy, testAddress)
 		err := anh.ReSendTransactionsIfRequired(context.Background())
-		require.Equal(t, expectedErr, err)
+		require.Equal(t, errExpected, err)
 	})
 	t.Run("proxy sendTransaction returns error shall error", func(t *testing.T) {
 		t.Parallel()
@@ -260,7 +260,7 @@ func TestAddressNonceHandler_ReSendTransactionsIfRequired(t *testing.T) {
 				}, nil
 			},
 			SendTransactionsCalled: func(_ context.Context, txs []*transaction.Transaction) ([]string, error) {
-				return make([]string, 0), expectedErr
+				return make([]string, 0), errExpected
 			},
 		}
 		anh, _ := NewAddressNonceHandlerWithPrivateAccess(proxy, testAddress)
@@ -274,7 +274,7 @@ func TestAddressNonceHandler_ReSendTransactionsIfRequired(t *testing.T) {
 
 		err = anh.ReSendTransactionsIfRequired(context.Background())
 		require.Equal(t, 1, len(anh.transactions))
-		require.Equal(t, expectedErr, err)
+		require.Equal(t, errExpected, err)
 	})
 	t.Run("account.Nonce == anh.computedNonce", func(t *testing.T) {
 		t.Parallel()

--- a/clients/klever/proxy/errors.go
+++ b/clients/klever/proxy/errors.go
@@ -53,15 +53,6 @@ type GenericAPIResponse struct {
 	Code  string      `json:"code"`
 }
 
-func createHTTPStatusError(httpStatusCode int, err error) error {
-	if err == nil {
-		err = ErrHTTPStatusCodeIsNotOK
-	}
-
-	return fmt.Errorf("%w, returned http status: %d, %s",
-		err, httpStatusCode, http.StatusText(httpStatusCode))
-}
-
 func createHTTPStatusErrorWithBody(httpStatusCode int, err error, responseBody []byte) error {
 	if err == nil {
 		err = ErrHTTPStatusCodeIsNotOK

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -145,6 +145,8 @@ func startRelay(ctx *cli.Context, version string) error {
 		return err
 	}
 
+	ethClientStatusHandler.SetIntMetric(core.MetricRelayerStartTime, int(time.Now().Unix()))
+
 	kleverClientStatusHandler, err := status.NewStatusHandler(core.KleverClientStatusHandlerName, statusStorer)
 	if err != nil {
 		return err

--- a/core/constants.go
+++ b/core/constants.go
@@ -93,9 +93,6 @@ const (
 	// MetricIsLeader represents the metric used to store if the relayer is a leader
 	MetricIsLeader = "is leader"
 
-	// MetricLeaderRotationRound represents the metric used to store the leader rotation round
-	MetricLeaderRotationRound = "leader rotation round"
-
 	// MetricRelayerStartTime represents the metric used to store the relayer start time
 	MetricRelayerStartTime = "relayer start time"
 

--- a/core/constants.go
+++ b/core/constants.go
@@ -77,12 +77,37 @@ const (
 
 	// MetricLastBlockNonce represents the last block nonce queried
 	MetricLastBlockNonce = "last block nonce"
+
+	// MetricConnectedP2PPeerCount represents the metric used to store the connected P2P peer count
+	MetricConnectedP2PPeerCount = "connected P2P peer count"
+
+	// MetricBridgeDirection represents the metric used to store the bridge direction
+	MetricBridgeDirection = "bridge direction"
+
+	// MetricCurrentBatchID represents the metric used to store the current batch ID
+	MetricCurrentBatchID = "current batch id"
+
+	// MetricCurrentDepositNonce represents the metric used to store the current deposit nonce
+	MetricCurrentDepositNonce = "current deposit nonce"
+
+	// MetricIsLeader represents the metric used to store if the relayer is a leader
+	MetricIsLeader = "is leader"
+
+	// MetricLeaderRotationRound represents the metric used to store the leader rotation round
+	MetricLeaderRotationRound = "leader rotation round"
+
+	// MetricRelayerStartTime represents the metric used to store the relayer start time
+	MetricRelayerStartTime = "relayer start time"
+
+	// MetricRelayerUptimeSeconds represents the metric used to store the relayer uptime in seconds
+	MetricRelayerUptimeSeconds = "relayer uptime seconds"
 )
 
 // PersistedMetrics represents the array of metrics that should be persisted
 var PersistedMetrics = []string{MetricNumBatches, MetricNumEthClientRequests, MetricNumEthClientTransactions,
 	MetricLastQueriedEthereumBlockNumber, MetricLastQueriedKCBlockNumber, MetricEthereumClientStatus,
-	MetricKCClientStatus, MetricLastEthereumClientError, MetricLastKCClientError, MetricLastBlockNonce}
+	MetricKCClientStatus, MetricLastEthereumClientError, MetricLastKCClientError, MetricLastBlockNonce,
+	MetricRelayerStartTime}
 
 const (
 	// EthClientStatusHandlerName is the Ethereum client status handler name

--- a/executors/ethereum/migrationBatchCreator_test.go
+++ b/executors/ethereum/migrationBatchCreator_test.go
@@ -25,7 +25,7 @@ var balanceOfTkn1 = big.NewInt(19)
 var balanceOfTkn2 = big.NewInt(38)
 var balanceOfTkn3 = big.NewInt(138)
 var balanceOfTkn4 = big.NewInt(1137)
-var expectedErr = errors.New("expected error")
+var errExpected = errors.New("expected error")
 
 func createMockArgsForMigrationBatchCreator() ArgsMigrationBatchCreator {
 	return ArgsMigrationBatchCreator{
@@ -111,17 +111,17 @@ func TestFindAnUsableBatchID(t *testing.T) {
 
 		result, err := testFindAnUsableBatchID(t, 1367, 1)
 		assert.Nil(t, result)
-		assert.ErrorIs(t, err, expectedErr)
+		assert.ErrorIs(t, err, errExpected)
 		assert.Contains(t, err.Error(), "on batch 1")
 
 		result, err = testFindAnUsableBatchID(t, 1367, 100000)
 		assert.Nil(t, result)
-		assert.ErrorIs(t, err, expectedErr)
+		assert.ErrorIs(t, err, errExpected)
 		assert.Contains(t, err.Error(), "on batch 100000")
 
 		result, err = testFindAnUsableBatchID(t, 1367, 50000)
 		assert.Nil(t, result)
-		assert.ErrorIs(t, err, expectedErr)
+		assert.ErrorIs(t, err, errExpected)
 		assert.Contains(t, err.Error(), "on batch 50000")
 	})
 	t.Run("should resolve in an optimum number of steps", func(t *testing.T) {
@@ -262,7 +262,7 @@ func testFindAnUsableBatchID(t *testing.T, firstFreeBatchId uint64, errorBatchID
 			batchNonceUint64 := batchNonce.Uint64()
 
 			if batchNonceUint64 == errorBatchID {
-				return false, fmt.Errorf("%w on batch %d", expectedErr, batchNonceUint64)
+				return false, fmt.Errorf("%w on batch %d", errExpected, batchNonceUint64)
 			}
 
 			checkedMap[batchNonceUint64]++
@@ -292,13 +292,13 @@ func TestMigrationBatchCreator_CreateBatchInfo(t *testing.T) {
 		args := createMockArgsForMigrationBatchCreator()
 		args.EthereumChainWrapper = &bridge.EthereumClientWrapperStub{
 			WasBatchExecutedCalled: func(ctx context.Context, batchNonce *big.Int) (bool, error) {
-				return false, expectedErr
+				return false, errExpected
 			},
 		}
 
 		creator, _ := NewMigrationBatchCreator(args)
 		batch, err := creator.CreateBatchInfo(context.Background(), newSafeContractAddress, nil)
-		assert.Equal(t, expectedErr, err)
+		assert.Equal(t, errExpected, err)
 		assert.Nil(t, batch)
 	})
 	t.Run("get all known tokens errors should error", func(t *testing.T) {
@@ -312,13 +312,13 @@ func TestMigrationBatchCreator_CreateBatchInfo(t *testing.T) {
 		}
 		args.KlvDataGetter = &bridge.DataGetterStub{
 			GetAllKnownTokensCalled: func(ctx context.Context) ([][]byte, error) {
-				return nil, expectedErr
+				return nil, errExpected
 			},
 		}
 
 		creator, _ := NewMigrationBatchCreator(args)
 		batch, err := creator.CreateBatchInfo(context.Background(), newSafeContractAddress, nil)
-		assert.Equal(t, expectedErr, err)
+		assert.Equal(t, errExpected, err)
 		assert.Nil(t, batch)
 	})
 	t.Run("get all known tokens returns 0 tokens should error", func(t *testing.T) {
@@ -351,12 +351,12 @@ func TestMigrationBatchCreator_CreateBatchInfo(t *testing.T) {
 			},
 		}
 		args.KlvDataGetter.(*bridge.DataGetterStub).GetERC20AddressForTokenIdCalled = func(ctx context.Context, sourceBytes []byte) ([][]byte, error) {
-			return nil, expectedErr
+			return nil, errExpected
 		}
 
 		creator, _ := NewMigrationBatchCreator(args)
 		batch, err := creator.CreateBatchInfo(context.Background(), newSafeContractAddress, nil)
-		assert.Equal(t, expectedErr, err)
+		assert.Equal(t, errExpected, err)
 		assert.Nil(t, batch)
 	})
 	t.Run("GetERC20AddressForTokenId returns empty list should error", func(t *testing.T) {
@@ -388,13 +388,13 @@ func TestMigrationBatchCreator_CreateBatchInfo(t *testing.T) {
 		}
 		args.Erc20ContractsHolder = &bridge.ERC20ContractsHolderStub{
 			BalanceOfCalled: func(ctx context.Context, erc20Address common.Address, address common.Address) (*big.Int, error) {
-				return nil, expectedErr
+				return nil, errExpected
 			},
 		}
 
 		creator, _ := NewMigrationBatchCreator(args)
 		batch, err := creator.CreateBatchInfo(context.Background(), newSafeContractAddress, nil)
-		assert.ErrorIs(t, err, expectedErr)
+		assert.ErrorIs(t, err, errExpected)
 		assert.Nil(t, batch)
 	})
 	t.Run("should work", func(t *testing.T) {

--- a/executors/ethereum/migrationBatchExecutor_test.go
+++ b/executors/ethereum/migrationBatchExecutor_test.go
@@ -190,7 +190,7 @@ func TestMigrationBatchExecutor_checkRelayersSigsAndQuorum(t *testing.T) {
 			{
 				Address:     ethCrypto.PubkeyToAddress(privateKeys[5].PublicKey).String(),
 				MessageHash: testMsgHash.String(),
-				Signature:   strings.Replace(correctSigForFifthElement, "1", "2", -1),
+				Signature:   strings.ReplaceAll(correctSigForFifthElement, "1", "2"),
 			},
 			// repeated good sig[1]
 			{

--- a/factory/ethKcBridgeComponents.go
+++ b/factory/ethKcBridgeComponents.go
@@ -519,6 +519,8 @@ func (components *ethKleverBridgeComponents) createEthereumToKleverBlockchainBri
 		return err
 	}
 
+	components.ethtoKleverStatusHandler.SetStringMetric(core.MetricBridgeDirection, "ETH->KC")
+
 	timeForTransferExecution := time.Second * time.Duration(args.Configs.GeneralConfig.Eth.IntervalToWaitForTransferInSeconds)
 
 	balanceValidator, err := components.createBalanceValidator()
@@ -586,6 +588,8 @@ func (components *ethKleverBridgeComponents) createKCToEthereumBridge(args ArgsE
 	if err != nil {
 		return err
 	}
+
+	components.kcToEthStatusHandler.SetStringMetric(core.MetricBridgeDirection, "KC->ETH")
 
 	timeForWaitOnEthereum := time.Second * time.Duration(args.Configs.GeneralConfig.Eth.IntervalToWaitForTransferInSeconds)
 

--- a/factory/ethKcBridgeComponents.go
+++ b/factory/ethKcBridgeComponents.go
@@ -519,7 +519,7 @@ func (components *ethKleverBridgeComponents) createEthereumToKleverBlockchainBri
 		return err
 	}
 
-	components.ethtoKleverStatusHandler.SetStringMetric(core.MetricBridgeDirection, "ETH->KC")
+	components.ethtoKleverStatusHandler.SetStringMetric(core.MetricBridgeDirection, ethtokleverName)
 
 	timeForTransferExecution := time.Second * time.Duration(args.Configs.GeneralConfig.Eth.IntervalToWaitForTransferInSeconds)
 
@@ -589,7 +589,7 @@ func (components *ethKleverBridgeComponents) createKCToEthereumBridge(args ArgsE
 		return err
 	}
 
-	components.kcToEthStatusHandler.SetStringMetric(core.MetricBridgeDirection, "KC->ETH")
+	components.kcToEthStatusHandler.SetStringMetric(core.MetricBridgeDirection, kcToEthName)
 
 	timeForWaitOnEthereum := time.Second * time.Duration(args.Configs.GeneralConfig.Eth.IntervalToWaitForTransferInSeconds)
 

--- a/integrationTests/relayers/slowTests/framework/testSetup.go
+++ b/integrationTests/relayers/slowTests/framework/testSetup.go
@@ -355,7 +355,7 @@ func (setup *TestSetup) sendFromKCToEthereumForToken(params TestTokenParams) *bi
 // TestWithdrawTotalFeesOnEthereumForTokens will test the withdrawal functionality for the provided test tokens
 func (setup *TestSetup) TestWithdrawTotalFeesOnEthereumForTokens(tokensParams ...TestTokenParams) {
 	for _, param := range tokensParams {
-		token := setup.TokensRegistry.GetTokenData(param.AbstractTokenIdentifier)
+		token := setup.GetTokenData(param.AbstractTokenIdentifier)
 
 		expectedAccumulated := big.NewInt(0)
 		for _, operation := range param.TestOperations {

--- a/p2p/statusHandlerAdapter.go
+++ b/p2p/statusHandlerAdapter.go
@@ -3,6 +3,7 @@ package p2p
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/klever-io/klv-bridge-eth-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/check"
@@ -17,6 +18,7 @@ type ArgsStatusHandlerAdapter struct {
 type statusHandlerAdapter struct {
 	core.StatusHandler
 	messenger NetMessenger
+	startTime time.Time
 }
 
 // NewStatusHandlerAdapter creates a new instance of statusHandlerAdapter able to gather p2p status metrics
@@ -31,6 +33,7 @@ func NewStatusHandlerAdapter(args ArgsStatusHandlerAdapter) (*statusHandlerAdapt
 	return &statusHandlerAdapter{
 		StatusHandler: args.StatusHandler,
 		messenger:     args.Messenger,
+		startTime:     time.Now(),
 	}, nil
 }
 
@@ -41,6 +44,9 @@ func (adapter *statusHandlerAdapter) Execute(_ context.Context) error {
 
 	connectedAddresses := adapter.messenger.ConnectedAddresses()
 	adapter.SetStringMetric(core.MetricConnectedP2PAddresses, strings.Join(connectedAddresses, " "))
+
+	adapter.SetIntMetric(core.MetricConnectedP2PPeerCount, len(connectedAddresses))
+	adapter.SetIntMetric(core.MetricRelayerUptimeSeconds, int(time.Since(adapter.startTime).Seconds()))
 
 	return nil
 }

--- a/p2p/statusHandlerAdapter_test.go
+++ b/p2p/statusHandlerAdapter_test.go
@@ -67,11 +67,11 @@ func TestStatusHandlerAdapter_Execute(t *testing.T) {
 	err := adapter.Execute(context.TODO())
 	assert.Nil(t, err)
 
-	expectedMetric := make(core.GeneralMetrics)
-	expectedMetric[core.MetricConnectedP2PAddresses] = strings.Join(connectedAddresses, " ")
-	expectedMetric[core.MetricRelayerP2PAddresses] = strings.Join(hostAddresses, " ")
-
 	metrics := adapter.GetAllMetrics()
-	assert.Equal(t, 2, len(metrics))
-	assert.Equal(t, expectedMetric, metrics)
+	assert.Equal(t, strings.Join(connectedAddresses, " "), metrics[core.MetricConnectedP2PAddresses])
+	assert.Equal(t, strings.Join(hostAddresses, " "), metrics[core.MetricRelayerP2PAddresses])
+	assert.Equal(t, len(connectedAddresses), metrics[core.MetricConnectedP2PPeerCount])
+	uptimeVal, ok := metrics[core.MetricRelayerUptimeSeconds]
+	assert.True(t, ok)
+	assert.GreaterOrEqual(t, uptimeVal, 0)
 }

--- a/testsCommon/bridge/bridgeExecutorStub.go
+++ b/testsCommon/bridge/bridgeExecutorStub.go
@@ -91,7 +91,7 @@ func (stub *BridgeExecutorStub) GetBatchFromKC(ctx context.Context) (*bridgeCore
 	if stub.GetBatchFromKCCalled != nil {
 		return stub.GetBatchFromKCCalled(ctx)
 	}
-	return nil, notImplemented
+	return nil, errNotImplemented
 }
 
 // StoreBatchFromKC -
@@ -100,7 +100,7 @@ func (stub *BridgeExecutorStub) StoreBatchFromKC(batch *bridgeCore.TransferBatch
 	if stub.StoreBatchFromKCCalled != nil {
 		return stub.StoreBatchFromKCCalled(batch)
 	}
-	return notImplemented
+	return errNotImplemented
 }
 
 // GetStoredBatch -
@@ -118,7 +118,7 @@ func (stub *BridgeExecutorStub) GetLastExecutedEthBatchIDFromKC(ctx context.Cont
 	if stub.GetLastExecutedEthBatchIDFromKCCalled != nil {
 		return stub.GetLastExecutedEthBatchIDFromKCCalled(ctx)
 	}
-	return 0, notImplemented
+	return 0, errNotImplemented
 }
 
 // VerifyLastDepositNonceExecutedOnEthereumBatch -
@@ -127,7 +127,7 @@ func (stub *BridgeExecutorStub) VerifyLastDepositNonceExecutedOnEthereumBatch(ct
 	if stub.VerifyLastDepositNonceExecutedOnEthereumBatchCalled != nil {
 		return stub.VerifyLastDepositNonceExecutedOnEthereumBatchCalled(ctx)
 	}
-	return notImplemented
+	return errNotImplemented
 }
 
 // GetAndStoreActionIDForProposeTransferOnKC -
@@ -136,7 +136,7 @@ func (stub *BridgeExecutorStub) GetAndStoreActionIDForProposeTransferOnKC(ctx co
 	if stub.GetAndStoreActionIDForProposeTransferOnKCCalled != nil {
 		return stub.GetAndStoreActionIDForProposeTransferOnKCCalled(ctx)
 	}
-	return 0, notImplemented
+	return 0, errNotImplemented
 }
 
 // GetAndStoreActionIDForProposeSetStatusFromKC -
@@ -145,7 +145,7 @@ func (stub *BridgeExecutorStub) GetAndStoreActionIDForProposeSetStatusFromKC(ctx
 	if stub.GetAndStoreActionIDForProposeSetStatusFromKCCalled != nil {
 		return stub.GetAndStoreActionIDForProposeSetStatusFromKCCalled(ctx)
 	}
-	return 0, notImplemented
+	return 0, errNotImplemented
 }
 
 // GetStoredActionID -
@@ -163,7 +163,7 @@ func (stub *BridgeExecutorStub) WasTransferProposedOnKC(ctx context.Context) (bo
 	if stub.WasTransferProposedOnKCCalled != nil {
 		return stub.WasTransferProposedOnKCCalled(ctx)
 	}
-	return false, notImplemented
+	return false, errNotImplemented
 }
 
 // ProposeTransferOnKC -
@@ -172,7 +172,7 @@ func (stub *BridgeExecutorStub) ProposeTransferOnKC(ctx context.Context) error {
 	if stub.ProposeTransferOnKCCalled != nil {
 		return stub.ProposeTransferOnKCCalled(ctx)
 	}
-	return notImplemented
+	return errNotImplemented
 }
 
 // ProcessMaxRetriesOnWasTransferProposedOnKC -
@@ -198,7 +198,7 @@ func (stub *BridgeExecutorStub) WasSetStatusProposedOnKC(ctx context.Context) (b
 	if stub.WasSetStatusProposedOnKCCalled != nil {
 		return stub.WasSetStatusProposedOnKCCalled(ctx)
 	}
-	return false, notImplemented
+	return false, errNotImplemented
 }
 
 // ProposeSetStatusOnKC -
@@ -207,7 +207,7 @@ func (stub *BridgeExecutorStub) ProposeSetStatusOnKC(ctx context.Context) error 
 	if stub.ProposeSetStatusOnKCCalled != nil {
 		return stub.ProposeSetStatusOnKCCalled(ctx)
 	}
-	return notImplemented
+	return errNotImplemented
 }
 
 // WasActionSignedOnKC -
@@ -216,7 +216,7 @@ func (stub *BridgeExecutorStub) WasActionSignedOnKC(ctx context.Context) (bool, 
 	if stub.WasActionSignedOnKCCalled != nil {
 		return stub.WasActionSignedOnKCCalled(ctx)
 	}
-	return false, notImplemented
+	return false, errNotImplemented
 }
 
 // SignActionOnKC -
@@ -225,7 +225,7 @@ func (stub *BridgeExecutorStub) SignActionOnKC(ctx context.Context) error {
 	if stub.SignActionOnKCCalled != nil {
 		return stub.SignActionOnKCCalled(ctx)
 	}
-	return notImplemented
+	return errNotImplemented
 }
 
 // ProcessQuorumReachedOnKC -
@@ -234,7 +234,7 @@ func (stub *BridgeExecutorStub) ProcessQuorumReachedOnKC(ctx context.Context) (b
 	if stub.ProcessQuorumReachedOnKCCalled != nil {
 		return stub.ProcessQuorumReachedOnKCCalled(ctx)
 	}
-	return false, notImplemented
+	return false, errNotImplemented
 }
 
 // WasActionPerformedOnKC -
@@ -243,7 +243,7 @@ func (stub *BridgeExecutorStub) WasActionPerformedOnKC(ctx context.Context) (boo
 	if stub.WasActionPerformedOnKCCalled != nil {
 		return stub.WasActionPerformedOnKCCalled(ctx)
 	}
-	return false, notImplemented
+	return false, errNotImplemented
 }
 
 // PerformActionOnKC -
@@ -252,7 +252,7 @@ func (stub *BridgeExecutorStub) PerformActionOnKC(ctx context.Context) error {
 	if stub.PerformActionOnKCCalled != nil {
 		return stub.PerformActionOnKCCalled(ctx)
 	}
-	return notImplemented
+	return errNotImplemented
 }
 
 // ResolveNewDepositsStatuses -
@@ -286,7 +286,7 @@ func (stub *BridgeExecutorStub) GetAndStoreBatchFromEthereum(ctx context.Context
 	if stub.GetAndStoreBatchFromEthereumCalled != nil {
 		return stub.GetAndStoreBatchFromEthereumCalled(ctx, nonce)
 	}
-	return notImplemented
+	return errNotImplemented
 }
 
 // WasTransferPerformedOnEthereum -
@@ -295,7 +295,7 @@ func (stub *BridgeExecutorStub) WasTransferPerformedOnEthereum(ctx context.Conte
 	if stub.WasTransferPerformedOnEthereumCalled != nil {
 		return stub.WasTransferPerformedOnEthereumCalled(ctx)
 	}
-	return false, notImplemented
+	return false, errNotImplemented
 }
 
 // SignTransferOnEthereum -
@@ -304,7 +304,7 @@ func (stub *BridgeExecutorStub) SignTransferOnEthereum() error {
 	if stub.SignTransferOnEthereumCalled != nil {
 		return stub.SignTransferOnEthereumCalled()
 	}
-	return notImplemented
+	return errNotImplemented
 }
 
 // PerformTransferOnEthereum -
@@ -313,7 +313,7 @@ func (stub *BridgeExecutorStub) PerformTransferOnEthereum(ctx context.Context) e
 	if stub.PerformTransferOnEthereumCalled != nil {
 		return stub.PerformTransferOnEthereumCalled(ctx)
 	}
-	return notImplemented
+	return errNotImplemented
 }
 
 // ProcessQuorumReachedOnEthereum -
@@ -322,7 +322,7 @@ func (stub *BridgeExecutorStub) ProcessQuorumReachedOnEthereum(ctx context.Conte
 	if stub.ProcessQuorumReachedOnEthereumCalled != nil {
 		return stub.ProcessQuorumReachedOnEthereumCalled(ctx)
 	}
-	return false, notImplemented
+	return false, errNotImplemented
 }
 
 // WaitForTransferConfirmation -
@@ -348,7 +348,7 @@ func (stub *BridgeExecutorStub) GetBatchStatusesFromEthereum(ctx context.Context
 	if stub.GetBatchStatusesFromEthereumCalled != nil {
 		return stub.GetBatchStatusesFromEthereumCalled(ctx)
 	}
-	return nil, notImplemented
+	return nil, errNotImplemented
 }
 
 // ProcessMaxQuorumRetriesOnEthereum -
@@ -381,7 +381,7 @@ func (stub *BridgeExecutorStub) CheckKCClientAvailability(ctx context.Context) e
 	if stub.CheckKCClientAvailabilityCalled != nil {
 		return stub.CheckKCClientAvailabilityCalled(ctx)
 	}
-	return notImplemented
+	return errNotImplemented
 }
 
 // CheckEthereumClientAvailability -
@@ -389,7 +389,7 @@ func (stub *BridgeExecutorStub) CheckEthereumClientAvailability(ctx context.Cont
 	if stub.CheckEthereumClientAvailabilityCalled != nil {
 		return stub.CheckEthereumClientAvailabilityCalled(ctx)
 	}
-	return notImplemented
+	return errNotImplemented
 }
 
 // IsInterfaceNil -

--- a/testsCommon/bridge/constants.go
+++ b/testsCommon/bridge/constants.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 )
 
-var notImplemented = errors.New("method not implemented")
+var errNotImplemented = errors.New("method not implemented")
 
 // CallDataMock -
 var CallDataMock = func() []byte {

--- a/testsCommon/bridge/contractBackendStub.go
+++ b/testsCommon/bridge/contractBackendStub.go
@@ -27,75 +27,75 @@ func (stub *ContractBackendStub) CodeAt(ctx context.Context, contract common.Add
 	if stub.CodeAtCalled != nil {
 		return stub.CodeAtCalled(ctx, contract, blockNumber)
 	}
-	return nil, notImplemented
+	return nil, errNotImplemented
 }
 
 func (stub *ContractBackendStub) CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
 	if stub.CallContractCalled != nil {
 		return stub.CallContractCalled(ctx, call, blockNumber)
 	}
-	return nil, notImplemented
+	return nil, errNotImplemented
 }
 
 func (stub *ContractBackendStub) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
 	if stub.HeaderByNumberCalled != nil {
 		return stub.HeaderByNumberCalled(ctx, number)
 	}
-	return nil, notImplemented
+	return nil, errNotImplemented
 }
 
 func (stub *ContractBackendStub) PendingCodeAt(ctx context.Context, account common.Address) ([]byte, error) {
 	if stub.PendingCodeAtCalled != nil {
 		return stub.PendingCodeAtCalled(ctx, account)
 	}
-	return nil, notImplemented
+	return nil, errNotImplemented
 }
 
 func (stub *ContractBackendStub) PendingNonceAt(ctx context.Context, account common.Address) (uint64, error) {
 	if stub.PendingNonceAtCalled != nil {
 		return stub.PendingNonceAtCalled(ctx, account)
 	}
-	return 0, notImplemented
+	return 0, errNotImplemented
 }
 
 func (stub *ContractBackendStub) SuggestGasPrice(ctx context.Context) (*big.Int, error) {
 	if stub.SuggestGasPriceCalled != nil {
 		return stub.SuggestGasPriceCalled(ctx)
 	}
-	return nil, notImplemented
+	return nil, errNotImplemented
 }
 
 func (stub *ContractBackendStub) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
 	if stub.SuggestGasTipCapCalled != nil {
 		return stub.SuggestGasTipCapCalled(ctx)
 	}
-	return nil, notImplemented
+	return nil, errNotImplemented
 }
 
 func (stub *ContractBackendStub) EstimateGas(ctx context.Context, call ethereum.CallMsg) (gas uint64, err error) {
 	if stub.EstimateGasCalled != nil {
 		return stub.EstimateGasCalled(ctx, call)
 	}
-	return 0, notImplemented
+	return 0, errNotImplemented
 }
 
 func (stub *ContractBackendStub) SendTransaction(ctx context.Context, tx *types.Transaction) error {
 	if stub.SendTransactionCalled != nil {
 		return stub.SendTransactionCalled(ctx, tx)
 	}
-	return notImplemented
+	return errNotImplemented
 }
 
 func (stub *ContractBackendStub) FilterLogs(ctx context.Context, query ethereum.FilterQuery) ([]types.Log, error) {
 	if stub.FilterLogsCalled != nil {
 		return stub.FilterLogsCalled(ctx, query)
 	}
-	return nil, notImplemented
+	return nil, errNotImplemented
 }
 
 func (stub *ContractBackendStub) SubscribeFilterLogs(ctx context.Context, query ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
 	if stub.SubscribeFilterLogsCalled != nil {
 		return stub.SubscribeFilterLogsCalled(ctx, query, ch)
 	}
-	return nil, notImplemented
+	return nil, errNotImplemented
 }

--- a/testsCommon/bridge/kcClientStub.go
+++ b/testsCommon/bridge/kcClientStub.go
@@ -2,13 +2,10 @@ package bridge
 
 import (
 	"context"
-	"errors"
 	"math/big"
 
 	bridgeCore "github.com/klever-io/klv-bridge-eth-go/core"
 )
-
-var errNotImplemented = errors.New("not implemented")
 
 // KCClientStub -
 type KCClientStub struct {
@@ -228,7 +225,7 @@ func (stub *KCClientStub) IsMintBurnToken(ctx context.Context, token []byte) (bo
 	if stub.IsMintBurnTokenCalled != nil {
 		return stub.IsMintBurnTokenCalled(ctx, token)
 	}
-	return false, notImplemented
+	return false, errNotImplemented
 }
 
 // IsNativeToken -
@@ -236,7 +233,7 @@ func (stub *KCClientStub) IsNativeToken(ctx context.Context, token []byte) (bool
 	if stub.IsNativeTokenCalled != nil {
 		return stub.IsNativeTokenCalled(ctx, token)
 	}
-	return false, notImplemented
+	return false, errNotImplemented
 }
 
 // TotalBalances -
@@ -244,7 +241,7 @@ func (stub *KCClientStub) TotalBalances(ctx context.Context, token []byte) (*big
 	if stub.TotalBalancesCalled != nil {
 		return stub.TotalBalancesCalled(ctx, token)
 	}
-	return nil, notImplemented
+	return nil, errNotImplemented
 }
 
 // MintBalances -
@@ -252,7 +249,7 @@ func (stub *KCClientStub) MintBalances(ctx context.Context, token []byte) (*big.
 	if stub.MintBalancesCalled != nil {
 		return stub.MintBalancesCalled(ctx, token)
 	}
-	return nil, notImplemented
+	return nil, errNotImplemented
 }
 
 // BurnBalances -
@@ -260,7 +257,7 @@ func (stub *KCClientStub) BurnBalances(ctx context.Context, token []byte) (*big.
 	if stub.BurnBalancesCalled != nil {
 		return stub.BurnBalancesCalled(ctx, token)
 	}
-	return nil, notImplemented
+	return nil, errNotImplemented
 }
 
 // CheckRequiredBalance -


### PR DESCRIPTION
## Summary
- Add 8 new monitoring metrics to the bridge relayer API: P2P peer count, bridge direction, current batch ID, current deposit nonce, leader status, leader rotation round, relayer start time, and relayer uptime
- Resolve all golangci-lint issues across the codebase (duplicate imports, error var naming, unused code)

## Changes
- `core/constants.go` — New metric constants and persisted metrics
- `p2p/statusHandlerAdapter.go` — P2P peer count and uptime tracking
- `bridges/ethKC/bridgeExecutor.go` — Batch ID, deposit nonce, leader status metrics
- `factory/ethKcBridgeComponents.go` — Bridge direction metric per handler
- `cmd/bridge/main.go` — Relayer start time metric
- Lint fixes across 26 files (ST1019, ST1012, QF1004, QF1008, unused function)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] `golangci-lint run` reports 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added metrics: relayer start time, uptime seconds, connected P2P peer count, bridge direction, current batch ID, and current deposit nonce; leader status is now tracked.

* **Improvements**
  * Initialize bridge direction and status metrics at startup; status handlers now drive metric updates for bridge operations.
  * P2P adapter reports connected peer count and uptime.

* **Tests**
  * Strengthened tests with explicit status/metric assertions and standardized test error variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->